### PR TITLE
Update to rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ impl Object {
         let pairs = s.split(' ');
         let mut points = Vec::new();
         for v in pairs.map(|&:p| p.splitn(1, ',')) {
-            let v: Vec<&str> = v.clone().collect();
+            let v: Vec<&str> = v.collect();
             if v.len() != 2 {
                 return Err(TiledError::MalformedAttributes("one of a polyline's points does not have an x and y coordinate".to_string()));
             }


### PR DESCRIPTION
In the new nightly it seems std::str::Split doesn't implement Clone anymore.

```
rustc --version
rustc 1.0.0-nightly (4db0b3246 2015-02-25) (built 2015-02-26)
```

See: https://travis-ci.org/search/rs-tiledato