### PR TITLE
Fix for "private type in exported type signature"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use flate2::read::{ZlibDecoder, GzDecoder};
 use std::num::from_str_radix;
 
 #[derive(Debug)]
-enum ParseTileError {
+pub enum ParseTileError {
     ColourError,
     OrientationError,
 }


### PR DESCRIPTION
Made `ParseTileError` public to avoid exposing a private type trought the trait `FromStr` for `Color`.

```
$ rustc --version
rustc 1.0.0-nightly (fed12499e 2015-03-03) (built 2015-03-04)
```