### PR TITLE
Fix dependencies to make the main library compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,7 @@ path = "examples/piston.rs"
 [dependencies]
 flate2 = "*"
 rustc-serialize = "*"
-
-[dependencies.xml-rs]
-git = "https://github.com/netvl/xml-rs.git"
+xml-rs = "0.1.26"
 
 
 [dev-dependencies.pistoncore-sdl2_window]


### PR DESCRIPTION
The Piston example being built with 'cargo test' is also broken, probably needs a more detailed look. This fix should be enough to keep the library usable as a dependency.