### PR TITLE
Edited orientation keywords to be compatible with Tiled 0.14.2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ impl FromStr for Orientation {
         match s {
             "orthogonal" => Ok(Orientation::Orthogonal),
             "isometric" => Ok(Orientation::Isometric),
-            "Staggered" => Ok(Orientation::Staggered),
+            "staggered" => Ok(Orientation::Staggered),
             _ => Err(ParseTileError::OrientationError)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,8 @@ impl Map {
 pub enum Orientation {
     Orthogonal,
     Isometric,
-    Staggered
+    Staggered,
+    Hexagonal
 }
 
 impl FromStr for Orientation {
@@ -234,6 +235,7 @@ impl FromStr for Orientation {
             "orthogonal" => Ok(Orientation::Orthogonal),
             "isometric" => Ok(Orientation::Isometric),
             "staggered" => Ok(Orientation::Staggered),
+            "hexagonal" => Ok(Orientation::Hexagonal),
             _ => Err(ParseTileError::OrientationError)
         }
     }


### PR DESCRIPTION
I'm not sure whether it was a bug in an older Tiled version that the 'Staggered' keyword was capitalized, it's definitely inconsistent. Tiled 0.14.2 is a daily build in which that issue's been fixed, apparently.