### PR TITLE
Added tile id to image, since they don't have to start at 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ impl Tileset {
 
         let mut images = Vec::new();
         parse_tag!(parser, "tileset",
-                   "tile" => |attrs| {
+                   "image" => |attrs| {
                         images.push(try!(Image::new(parser, attrs)));
                         Ok(())
                    });
@@ -313,7 +313,6 @@ impl Tileset {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Image {
     /// The filepath of the image
-    pub id: u32,
     pub source: String,
     pub width: i32,
     pub height: i32,
@@ -322,29 +321,16 @@ pub struct Image {
 
 impl Image {
     fn new<R: Read>(parser: &mut EventReader<R>, attrs: Vec<OwnedAttribute>) -> Result<Image, TiledError> {
-        let i: ((), (u32)) = get_attrs!(
+        let (c, (s, w, h)) = get_attrs!(
             attrs,
-            optionals: [],
-            required: [("id", id, |v:String| v.parse().ok())],
-            TiledError::MalformedAttributes("tile must have an id with the correct type".to_string()));
+            optionals: [("trans", trans, |v:String| v.parse().ok())],
+            required: [("source", source, |v| Some(v)),
+                       ("width", width, |v:String| v.parse().ok()),
+                       ("height", height, |v:String| v.parse().ok())],
+            TiledError::MalformedAttributes("image must have a source, width and height with correct types".to_string()));
 
-        let mut image = None;
-        parse_tag!(parser, "tile",
-                   "image" => |attrs: Vec<OwnedAttribute>| {
-                       let (c, (s, w, h)) = get_attrs!(
-                            attrs,
-                            optionals: [("trans", trans, |v:String| v.parse().ok())],
-                            required: [("source", source, |v| Some(v)),
-                                    ("width", width, |v:String| v.parse().ok()),
-                                    ("height", height, |v:String| v.parse().ok())],
-                            TiledError::MalformedAttributes("image must have a source, width and height with correct types".to_string()));
-
-                        parse_tag!(parser, "image", "" => |_| Ok(()));
-                        image = Some(Image {id: i.1, source: s, width: w, height: h, transparent_colour: c});
-                        Ok(())
-                   });
-
-        Ok(image.unwrap())
+        parse_tag!(parser, "image", "" => |_| Ok(()));
+        Ok(Image {source: s, width: w, height: h, transparent_colour: c})
     }
 }
 


### PR DESCRIPTION
Images in `tileset` generally start at an id of 0, but if you remove all the images from a tileset and then add new ones, without recreating the tileset, they'll start where they left off, but the firstgid can still be one. For example, the situation that I discovered:
```xml
<tileset firstgid="1" name="Floors" tilewidth="32" tileheight="32" tilecount="18" columns="0">
  <tile id="54">
     <image width="32" height="32" source="../sprites/floors/experimentFloor1.png"/>
  </tile>
```
This commit adds an id to the Image struct which allows the user facing code to avoid this situation.