### PR TITLE
Add keywords metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ readme = "README.md"
 license = "MIT"
 authors = ["Matthew Hall <matthew@quickbeam.me.uk>"]
 
+keywords = ["tiled", "tmx", "map"]
+
 [lib]
 name = "tiled"
 path = "src/lib.rs"


### PR DESCRIPTION
Hi, it took me a while to find this crate in crates.io, I had used tiled (the editor) before and so searched for both tmx and maps but found nothing.

I think this would improve visibility for this crate