### PR TITLE
Load in properties from the tiles

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ impl FromStr for Orientation {
 }
 
 /// A tileset, usually the tilesheet image.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub struct Tileset {
     /// The GID of the first tile stored
     pub first_gid: u32,
@@ -420,10 +420,11 @@ impl Tileset {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub struct Tile {
     pub id: u32,
-    pub images: Vec<Image>
+    pub images: Vec<Image>,
+    pub properties: Properties,
 }
 
 impl Tile {
@@ -435,12 +436,17 @@ impl Tile {
             TiledError::MalformedAttributes("tile must have an id with the correct type".to_string()));
 
         let mut images = Vec::new();
+        let mut properties = HashMap::new();
         parse_tag!(parser, "tile",
                    "image" => |attrs| {
-                        images.push(try!(Image::new(parser, attrs)));
-                        Ok(())
-        });
-        Ok(Tile {id: i, images: images})
+                       images.push(Image::new(parser, attrs)?);
+                       Ok(())
+                   },
+                   "properties" => |_| {
+                       properties = parse_properties(parser)?;
+                       Ok(())
+                   });
+        Ok(Tile {id: i, images: images, properties: properties})
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,7 +2,7 @@ extern crate tiled;
 
 use std::path::Path;
 use std::fs::File;
-use tiled::{Map, TiledError, parse, parse_file, parse_tileset};
+use tiled::{Map, TiledError, PropertyValue, parse, parse_file, parse_tileset};
 
 fn read_from_file(p: &Path) -> Result<Map, TiledError> {
     let file = File::open(p).unwrap();
@@ -36,4 +36,15 @@ fn test_just_tileset() {
     let r = read_from_file(&Path::new("assets/tiled_base64.tmx")).unwrap();
     let t = parse_tileset(File::open(Path::new("assets/tilesheet.tsx")).unwrap(), 1).unwrap();
     assert_eq!(r.tilesets[0], t);
+}
+
+#[test]
+fn test_tile_property() {
+    let r = read_from_file(&Path::new("assets/tiled_base64.tmx")).unwrap();
+    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) = r.tilesets[0].tiles[0].properties.get("a tile property") {
+        v.clone()
+    } else {
+        String::new()
+    };
+    assert_eq!("123", prop_value);
 }


### PR DESCRIPTION
I had to remove Eq from the Tile and Tileset due to the fact that f32 does not implement it.