### PR TITLE
Update flate2 to the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ name = "example"
 path = "examples/main.rs"
 
 [dependencies]
-flate2 = "0.2.13"
 base64 = "0.1.1"
 xml-rs = "0.3.0"
+flate2 = "1.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,15 +802,9 @@ fn decode_zlib(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
 }
 
 fn decode_gzip(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
-    let mut gzd = match GzDecoder::new(BufReader::new(&data[..])) {
-        Ok(gzd) => gzd,
-        Err(e) => return Err(TiledError::DecompressingError(e))
-    };
+    let mut gzd = GzDecoder::new(BufReader::new(&data[..]));
     let mut data = Vec::new();
-    match gzd.read_to_end(&mut data) {
-        Ok(_v) => {},
-        Err(e) => return Err(TiledError::DecompressingError(e))
-    }
+    gzd.read_to_end(&mut data).map_err(|e| TiledError::DecompressingError(e))?;
     Ok(data)
 }
 


### PR DESCRIPTION
Currently used obsolete version of the flate2 crate conflicts with `ggez 0.4`