### PR TITLE
Support for groups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ path = "examples/main.rs"
 
 [dependencies]
 base64  = "0.5.2"
+downcast-rs = "1.0.3"
 xml-rs  = "0.3.0"
 libflate = "0.1.18"

--- a/assets/tiled_group_csv.tmx
+++ b/assets/tiled_group_csv.tmx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.2" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="8" nextobjectid="3">
+ <tileset firstgid="1" name="tilesheet" tilewidth="32" tileheight="32" tilecount="84" columns="14">
+  <image source="tilesheet.png" width="448" height="192"/>
+ </tileset>
+ <layer id="1" name="Tile Layer 1" width="10" height="10">
+  <data encoding="csv">
+43,43,43,43,43,43,43,43,43,43,
+17,6,7,7,7,7,7,7,8,17,
+17,20,21,21,21,21,21,21,22,17,
+17,20,21,21,21,21,21,21,22,17,
+17,20,21,21,21,21,21,21,22,17,
+17,20,21,21,21,21,21,21,22,17,
+17,20,21,21,21,21,21,21,22,17,
+17,20,21,21,21,21,21,21,22,17,
+17,34,35,35,35,35,35,35,36,17,
+29,29,29,29,29,29,29,29,29,29
+</data>
+ </layer>
+ <group id="2" name="group">
+  <group id="6" name="offsetgroup" offsetx="20" offsety="22">
+   <objectgroup id="7" name="objects2">
+    <object id="1" x="106" y="102" width="45" height="33"/>
+   </objectgroup>
+  </group>
+  <objectgroup id="4" name="objects">
+   <object id="2" x="41" y="49" width="45" height="42"/>
+  </objectgroup>
+  <layer id="5" name="Tile Layer 2" width="10" height="10">
+   <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
+</data>
+  </layer>
+ </group>
+</map>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,12 @@
+#[macro_use]
+extern crate downcast_rs;
 extern crate tiled;
 
-use std::path::Path;
 use std::fs::File;
-use tiled::{Map, TiledError, PropertyValue, parse, parse_file, parse_tileset};
+use std::path::Path;
+use tiled::{
+    parse, parse_file, parse_tileset, Group, Map, ObjectGroup, PropertyValue, TileLayer, TiledError,
+};
 
 fn read_from_file(p: &Path) -> Result<Map, TiledError> {
     let file = File::open(p).unwrap();
@@ -45,26 +49,55 @@ fn test_image_layers() {
     {
         let first = &r.image_layers[0];
         assert_eq!(first.name, "Image Layer 1");
-        assert!(first.image.is_none(), "{}'s image should be None", first.name);
+        assert!(
+            first.image.is_none(),
+            "{}'s image should be None",
+            first.name
+        );
     }
     {
         let second = &r.image_layers[1];
         assert_eq!(second.name, "Image Layer 2");
-        let image = second.image.as_ref().expect(&format!("{}'s image shouldn't be None", second.name));
+        let image = second
+            .image
+            .as_ref()
+            .expect(&format!("{}'s image shouldn't be None", second.name));
         assert_eq!(image.source, "tilesheet.png");
         assert_eq!(image.width, 448);
         assert_eq!(image.height, 192);
     }
 }
 
-
 #[test]
 fn test_tile_property() {
     let r = read_from_file(&Path::new("assets/tiled_base64.tmx")).unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) = r.tilesets[0].tiles[0].properties.get("a tile property") {
+    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) =
+        r.tilesets[0].tiles[0].properties.get("a tile property")
+    {
         v.clone()
     } else {
         String::new()
     };
     assert_eq!("123", prop_value);
+}
+
+#[test]
+fn test_nested_groups() {
+    let r = read_from_file(&Path::new("assets/tiled_group_csv.tmx")).unwrap();
+    assert_eq!(r.layers.len(), 1);
+    let group = r.groups.get(0).unwrap();
+    assert_eq!(group.children.len(), 3);
+
+    let second_group = group.children.get(0).unwrap().downcast_ref::<Group>();
+    assert!(second_group.is_some());
+    let second_group = second_group.unwrap();
+    assert_eq!(second_group.children.len(), 1);
+    assert_eq!(second_group.offset_x, 20.0);
+    assert_eq!(second_group.offset_y, 22.0);
+
+    let object_layer = group.children.get(1).unwrap().downcast_ref::<ObjectGroup>();
+    assert!(object_layer.is_some());
+
+    let tile_layer = group.children.get(2).unwrap().downcast_ref::<TileLayer>();
+    assert!(tile_layer.is_some());
 }


### PR DESCRIPTION
Hi there,

I started on a game project, wanting to use groups to sorta simulate a scene graph type representation. Given rs-tiled didn't have that, I thought I'd implement and submit a PR. Here's a summary of the changes:

* Breaking change - renamed `Layer` struct to `TileLayer`. Reason for this, is I needed a trait type that each layer type implemented, and I thought Layer was the more generic name. If you wish to avoid the breaking change, I can name it to something else. Definitely open to suggestions here
* Added the downcast crate, so the `Group` struct can store a `Vec<Layer>` and downcast into the specific types
* Some tests and code just got reformatted, as my editor uses fmt on save.
* Only thing I don't like is the bit of duplicate code in `parse_tag!` in the `Group::new` function. Which is fairly re-purposed from `Map::new`. If you have suggestions on how to refactor this, I am also open to suggestions. Though it's a little tricky, given that in `Group::new` the layers are pushed as a Box type to a single Vec instead of across many.