### PR TITLE
Fix tile flipping code

### DIFF
--- a/assets/tiled_flipped.tmx
+++ b/assets/tiled_flipped.tmx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.5" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
+ <tileset firstgid="1" source="tilesheet.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+3758096387,1073741827,
+2147483651,536870915
+</data>
+ </layer>
+</map>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -79,3 +79,27 @@ fn test_object_group_property() {
     };
     assert!(prop_value);
 }
+
+#[test]
+fn test_flipped_gid() {
+    let r = read_from_file_with_path(&Path::new("assets/tiled_flipped.tmx")).unwrap();
+    let t1 = r.layers[0].tiles[0][0];
+    let t2 = r.layers[0].tiles[0][1];
+    let t3 = r.layers[0].tiles[1][0];
+    let t4 = r.layers[0].tiles[1][1];
+    assert_eq!(t1.gid, t2.gid);
+    assert_eq!(t2.gid, t3.gid);
+    assert_eq!(t3.gid, t4.gid);
+    assert!(t1.flip_d);
+    assert!(t1.flip_h);
+    assert!(t1.flip_v);
+    assert!(!t2.flip_d);
+    assert!(!t2.flip_h);
+    assert!(t2.flip_v);
+    assert!(!t3.flip_d);
+    assert!(t3.flip_h);
+    assert!(!t3.flip_v);
+    assert!(t4.flip_d);
+    assert!(!t4.flip_h);
+    assert!(!t4.flip_v);
+}


### PR DESCRIPTION
As @alec-deason rightly pointed out, I messed up the tile flipping code, as it's not encoded into the tileset, but at the layer level. I was kinda dumb, and just assumed that Tile just meant tiles for layers, not tiles for tilesets. To correct my mistake, I rolled back the changes and implemented a new struct: LayerTile. It not only stores the tile gid, but the flags as well. For good measure, I also made it #[derive] Eq, PartialEq, Debug, Clone and Copy, but this is a significant change from the u32 gids.