### PR TITLE
Make fields on frame pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,10 @@ impl Tileset {
     fn new_external<R: Read>(file: R, first_gid: u32) -> Result<Tileset, TiledError> {
         let mut tileset_parser = EventReader::new(file);
         loop {
-            match tileset_parser.next().map_err(TiledError::XmlDecodingError)? {
+            match tileset_parser
+                .next()
+                .map_err(TiledError::XmlDecodingError)?
+            {
                 XmlEvent::StartElement {
                     name, attributes, ..
                 } => {
@@ -949,8 +952,8 @@ impl Object {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Frame {
-    tile_id: u32,
-    duration: u32,
+    pub tile_id: u32,
+    pub duration: u32,
 }
 
 impl Frame {


### PR DESCRIPTION
# Context
There doesn't seem to be a way to get at any of the fields on `Frame`.

Let's make it pub so we can poke at it.

# Technical
Ideally we'd add methods that just returned the tile id / duration without allowing modification of the source frame, but I decided to keep this in line with how the rest of the API looks.

Also, a minor rust fmt fix.