### PR TITLE
Feature-gate zstd so we can target wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2018"
 
 keywords = ["tiled", "tmx", "map"]
 
+[features]
+default = ["zstd"]
+
 [lib]
 name = "tiled"
 path = "src/lib.rs"
@@ -24,4 +27,4 @@ path = "examples/main.rs"
 base64  = "0.10"
 xml-rs  = "0.8"
 libflate = "0.1.18"
-zstd = "0.5"
+zstd = { version = "0.5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1131,6 +1131,7 @@ fn parse_data_line<R: Read>(encoding: Option<String>, compression: Option<String
                     .and_then(decode_gzip)
                     .map(|v| convert_to_tile(&v, width))
             }
+            #[cfg(feature = "zstd")]
             ("base64", "zstd") => {
                 return parse_base64(parser)
                     .and_then(decode_zstd)
@@ -1186,6 +1187,7 @@ fn decode_gzip(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
     Ok(data)
 }
 
+#[cfg(feature = "zstd")]
 fn decode_zstd(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
     use std::io::Cursor;
     use zstd::stream::read::Decoder;


### PR DESCRIPTION
Another option might be switching to [zstd-rs](https://github.com/KillingSpark/zstd-rs), but I haven't tested this and it seems that there would be a large performance penalty.

People who need compression and wasm can probably recompress with flate, so this seems like a good solution to me.