### PR TITLE
Object visibility needs parsed string, too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -907,7 +907,7 @@ impl Object {
                 ("type", obj_type, |v:String| v.parse().ok()),
                 ("width", width, |v:String| v.parse().ok()),
                 ("height", height, |v:String| v.parse().ok()),
-                ("visible", visible, |v:String| v.parse().ok()),
+                ("visible", visible, |v:String| v.parse().ok().map(|x:i32| x == 1)),
                 ("rotation", rotation, |v:String| v.parse().ok()),
             ],
             required: [


### PR DESCRIPTION
Layer and ObjectGroup are parsing the "visible" string, but Object seems to be missing this expression.
The [TMX docs](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#object) indicate that visible attribute is expected to be "0" or "1"