### PR TITLE
Refactor `get_attrs`

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -22,12 +22,11 @@ pub struct Frame {
 impl Frame {
     pub(crate) fn new(attrs: Vec<OwnedAttribute>) -> Result<Frame> {
         let (tile_id, duration) = get_attrs!(
-            attrs,
-            required: [
-                ("tileid", tile_id, |v:String| v.parse().ok()),
-                ("duration", duration, |v:String| v.parse().ok()),
-            ],
-            Error::MalformedAttributes("A frame must have tileid and duration".to_string())
+            for v in attrs {
+                "tileid" => tile_id ?= v.parse::<u32>(),
+                "duration" => duration ?= v.parse::<u32>(),
+            }
+            (tile_id, duration)
         );
         Ok(Frame { tile_id, duration })
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -84,16 +84,13 @@ impl Image {
         path_relative_to: impl AsRef<Path>,
     ) -> Result<Image> {
         let (c, (s, w, h)) = get_attrs!(
-            attrs,
-            optionals: [
-                ("trans", trans, |v:String| v.parse().ok()),
-            ],
-            required: [
-                ("source", source, Some),
-                ("width", width, |v:String| v.parse().ok()),
-                ("height", height, |v:String| v.parse().ok()),
-            ],
-            Error::MalformedAttributes("Image must have a source, width and height with correct types".to_string())
+            for v in attrs {
+                Some("trans") => trans ?= v.parse(),
+                "source" => source = v,
+                "width" => width ?= v.parse::<i32>(),
+                "height" => height ?= v.parse::<i32>(),
+            }
+            (trans, (source, width, height))
         );
 
         parse_tag!(parser, "image", {});

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -71,18 +71,18 @@ impl LayerData {
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id) = get_attrs!(
-            attrs,
-            optionals: [
-                ("opacity", opacity, |v:String| v.parse().ok()),
-                ("tintcolor", tint_color, |v:String| v.parse().ok()),
-                ("visible", visible, |v:String| v.parse().ok().map(|x:i32| x == 1)),
-                ("offsetx", offset_x, |v:String| v.parse().ok()),
-                ("offsety", offset_y, |v:String| v.parse().ok()),
-                ("parallaxx", parallax_x, |v:String| v.parse().ok()),
-                ("parallaxy", parallax_y, |v:String| v.parse().ok()),
-                ("name", name, Some),
-                ("id", id, |v:String| v.parse().ok()),
-            ]
+            for v in attrs {
+                Some("opacity") => opacity ?= v.parse(),
+                Some("tintcolor") => tint_color ?= v.parse(),
+                Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
+                Some("offsetx") => offset_x ?= v.parse(),
+                Some("offsety") => offset_y ?= v.parse(),
+                Some("parallaxx") => parallax_x ?= v.parse(),
+                Some("parallaxy") => parallax_y ?= v.parse(),
+                Some("name") => name = v,
+                Some("id") => id ?= v.parse(),
+            }
+            (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id)
         );
 
         let (ty, properties) = match tag {

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -25,10 +25,10 @@ impl ObjectLayerData {
         tilesets: Option<&[MapTilesetGid]>,
     ) -> Result<(ObjectLayerData, Properties)> {
         let c = get_attrs!(
-            attrs,
-            optionals: [
-                ("color", colour, |v:String| v.parse().ok()),
-            ]
+            for v in attrs {
+                Some("color") => color ?= v.parse(),
+            }
+            color
         );
         let mut objects = Vec::new();
         let mut properties = HashMap::new();

--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -46,11 +46,11 @@ impl FiniteTileLayerData {
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
-            attrs,
-            optionals: [
-                ("encoding", encoding, Some),
-                ("compression", compression, Some),
-            ]
+            for v in attrs {
+                Some("encoding") => encoding = v,
+                Some("compression") => compression = v,
+            }
+            (encoding, compression)
         );
 
         let tiles = parse_data_line(e, c, parser, tilesets)?;

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -28,11 +28,11 @@ impl InfiniteTileLayerData {
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
-            attrs,
-            optionals: [
-                ("encoding", encoding, Some),
-                ("compression", compression, Some),
-            ]
+            for v in attrs {
+                Some("encoding") => encoding = v,
+                Some("compression") => compression = v,
+            }
+            (encoding, compression)
         );
 
         let mut chunks = HashMap::<(i32, i32), Chunk>::new();
@@ -191,14 +191,13 @@ impl InternalChunk {
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (x, y, width, height) = get_attrs!(
-            attrs,
-            required: [
-                ("x", x, |v: String| v.parse().ok()),
-                ("y", y, |v: String| v.parse().ok()),
-                ("width", width, |v: String| v.parse().ok()),
-                ("height", height, |v: String| v.parse().ok()),
-            ],
-            Error::MalformedAttributes("chunk must have x, y, width & height attributes".to_string())
+            for v in attrs {
+                "x" => x ?= v.parse::<i32>(),
+                "y" => y ?= v.parse::<i32>(),
+                "width" => width ?= v.parse::<u32>(),
+                "height" => height ?= v.parse::<u32>(),
+            }
+            (x, y, width, height)
         );
 
         let tiles = parse_data_line(encoding, compression, parser, tilesets)?;

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -101,12 +101,11 @@ impl TileLayerData {
         tilesets: &[MapTilesetGid],
     ) -> Result<(Self, Properties)> {
         let (width, height) = get_attrs!(
-            attrs,
-            required: [
-                ("width", width, |v: String| v.parse().ok()),
-                ("height", height, |v: String| v.parse().ok()),
-            ],
-            Error::MalformedAttributes("layer parsing error, width and height attributes required".to_string())
+            for v in attrs {
+                "width" => width ?= v.parse::<u32>(),
+                "height" => height ?= v.parse::<u32>(),
+            }
+            (width, height)
         );
         let mut result = Self::Finite(Default::default());
         let mut properties = HashMap::new();

--- a/src/map.rs
+++ b/src/map.rs
@@ -158,20 +158,17 @@ impl Map {
         cache: &mut impl ResourceCache,
     ) -> Result<Map> {
         let ((c, infinite), (v, o, w, h, tw, th)) = get_attrs!(
-            attrs,
-            optionals: [
-                ("backgroundcolor", colour, |v:String| v.parse().ok()),
-                ("infinite", infinite, |v:String| Some(v == "1")),
-            ],
-            required: [
-                ("version", version, Some),
-                ("orientation", orientation, |v:String| v.parse().ok()),
-                ("width", width, |v:String| v.parse().ok()),
-                ("height", height, |v:String| v.parse().ok()),
-                ("tilewidth", tile_width, |v:String| v.parse().ok()),
-                ("tileheight", tile_height, |v:String| v.parse().ok()),
-            ],
-            Error::MalformedAttributes("map must have version, width, height, tilewidth, tileheight and orientation with correct types".to_string())
+            for v in attrs {
+                Some("backgroundcolor") => colour ?= v.parse(),
+                Some("infinite") => infinite = v == "1",
+                "version" => version = v,
+                "orientation" => orientation ?= v.parse::<Orientation>(),
+                "width" => width ?= v.parse::<u32>(),
+                "height" => height ?= v.parse::<u32>(),
+                "tilewidth" => tile_width ?= v.parse::<u32>(),
+                "tileheight" => tile_height ?= v.parse::<u32>(),
+            }
+            ((colour, infinite), (version, orientation, width, height, tile_width, tile_height))
         );
 
         let infinite = infinite.unwrap_or(false);
@@ -278,6 +275,7 @@ pub enum Orientation {
 }
 
 impl FromStr for Orientation {
+    // TODO(0.11): Change error type to OrientationParseErr or similar
     type Err = ();
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -135,16 +135,13 @@ pub(crate) fn parse_properties(
     let mut p = HashMap::new();
     parse_tag!(parser, "properties", {
         "property" => |attrs:Vec<OwnedAttribute>| {
-            let ((t, v_attr), k) = get_attrs!(
-                attrs,
-                optionals: [
-                    ("type", property_type, Some),
-                    ("value", value, Some),
-                ],
-                required: [
-                    ("name", key, Some),
-                ],
-                Error::MalformedAttributes("property must have a name and a value".to_string())
+            let (t, v_attr, k) = get_attrs!(
+                for attr in attrs {
+                    Some("type") => obj_type = attr,
+                    Some("value") => value = attr,
+                    "name" => name = attr
+                }
+                (obj_type, value, name)
             );
             let t = t.unwrap_or_else(|| "string".to_owned());
 

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -66,15 +66,12 @@ impl TileData {
         path_relative_to: &Path,
     ) -> Result<(TileId, TileData)> {
         let ((tile_type, probability), id) = get_attrs!(
-            attrs,
-            optionals: [
-                ("type", tile_type, |v:String| v.parse().ok()),
-                ("probability", probability, |v:String| v.parse().ok()),
-            ],
-            required: [
-                ("id", id, |v:String| v.parse::<u32>().ok()),
-            ],
-            Error::MalformedAttributes("tile must have an id with the correct type".to_string())
+            for v in attrs {
+                Some("type") => tile_type ?= v.parse(),
+                Some("probability") => probability ?= v.parse(),
+                "id" => id ?= v.parse::<u32>(),
+            }
+            ((tile_type, probability), id)
         );
 
         let mut image = Option::None;

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -138,20 +138,17 @@ impl Tileset {
         map_path: &Path,
     ) -> Result<EmbeddedParseResult> {
         let ((spacing, margin, columns, name), (tilecount, first_gid, tile_width, tile_height)) = get_attrs!(
-           attrs,
-           optionals: [
-                ("spacing", spacing, |v:String| v.parse().ok()),
-                ("margin", margin, |v:String| v.parse().ok()),
-                ("columns", columns, |v:String| v.parse().ok()),
-                ("name", name, Some),
-            ],
-           required: [
-                ("tilecount", tilecount, |v:String| v.parse().ok()),
-                ("firstgid", first_gid, |v:String| v.parse().ok().map(Gid)),
-                ("tilewidth", width, |v:String| v.parse().ok()),
-                ("tileheight", height, |v:String| v.parse().ok()),
-            ],
-            Error::MalformedAttributes("tileset must have a firstgid, tilecount, tilewidth, and tileheight with correct types".to_string())
+           for v in attrs {
+            Some("spacing") => spacing ?= v.parse(),
+            Some("margin") => margin ?= v.parse(),
+            Some("columns") => columns ?= v.parse(),
+            Some("name") => name = v,
+            "tilecount" => tilecount ?= v.parse::<u32>(),
+            "firstgid" => first_gid ?= v.parse::<u32>().map(Gid),
+            "tilewidth" => tile_width ?= v.parse::<u32>(),
+            "tileheight" => tile_height ?= v.parse::<u32>(),
+           }
+           ((spacing, margin, columns, name), (tilecount, first_gid, tile_width, tile_height))
         );
 
         let root_path = map_path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
@@ -180,12 +177,11 @@ impl Tileset {
         map_path: &Path,
     ) -> Result<EmbeddedParseResult> {
         let (first_gid, source) = get_attrs!(
-            attrs,
-            required: [
-                ("firstgid", first_gid, |v:String| v.parse().ok().map(Gid)),
-                ("source", name, Some),
-            ],
-            Error::MalformedAttributes("Tileset reference must have a firstgid and source with correct types".to_string())
+            for v in attrs {
+                "firstgid" => first_gid ?= v.parse::<u32>().map(Gid),
+                "source" => source = v,
+            }
+            (first_gid, source)
         );
 
         let tileset_path = map_path.parent().ok_or(Error::PathIsNotFile)?.join(source);
@@ -202,19 +198,17 @@ impl Tileset {
         path: &Path,
     ) -> Result<Tileset> {
         let ((spacing, margin, columns, name), (tilecount, tile_width, tile_height)) = get_attrs!(
-            attrs,
-            optionals: [
-                ("spacing", spacing, |v:String| v.parse().ok()),
-                ("margin", margin, |v:String| v.parse().ok()),
-                ("columns", columns, |v:String| v.parse().ok()),
-                ("name", name, Some),
-            ],
-            required: [
-                ("tilecount", tilecount, |v:String| v.parse().ok()),
-                ("tilewidth", width, |v:String| v.parse().ok()),
-                ("tileheight", height, |v:String| v.parse().ok()),
-            ],
-            Error::MalformedAttributes("tileset must have a name, tile width and height with correct types".to_string())
+            for v in attrs {
+                Some("spacing") => spacing ?= v.parse(),
+                Some("margin") => margin ?= v.parse(),
+                Some("columns") => columns ?= v.parse(),
+                Some("name") => name = v,
+
+                "tilecount" => tilecount ?= v.parse::<u32>(),
+                "tilewidth" => tile_width ?= v.parse::<u32>(),
+                "tileheight" => tile_height ?= v.parse::<u32>(),
+            }
+            ((spacing, margin, columns, name), (tilecount, tile_width, tile_height))
         );
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();


### PR DESCRIPTION
This was really, really hard and required a lot of macro magic, but I ended up being able to do it.

Changes `get_attrs!` from being used like this:
```rs
let ((spacing, margin, columns, name), (tilecount, tile_width, tile_height)) = get_attrs!(
            attrs,
            optionals: [
                ("spacing", spacing, |v:String| v.parse().ok()),
                ("margin", margin, |v:String| v.parse().ok()),
                ("columns", columns, |v:String| v.parse().ok()),
                ("name", name, Some),
            ],
            required: [
                ("tilecount", tilecount, |v:String| v.parse().ok()),
                ("tilewidth", width, |v:String| v.parse().ok()),
                ("tileheight", height, |v:String| v.parse().ok()),
            ],
            Error::MalformedAttributes("tileset must have a name, tile width and height with correct types".to_string())
        );
```
To this:
```rs
let ((spacing, margin, columns, name), (tilecount, tile_width, tile_height)) = get_attrs!(
    for v in attrs {
        Some("spacing") => spacing ?= v.parse(),
        Some("margin") => margin ?= v.parse(),
        Some("columns") => columns ?= v.parse(),
        Some("name") => name = v,

        "tilecount" => tilecount ?= v.parse::<u32>(),
        "tilewidth" => tile_width ?= v.parse::<u32>(),
        "tileheight" => tile_height ?= v.parse::<u32>(),
    }
    ((spacing, margin, columns, name), (tilecount, tile_width, tile_height))
);
```
Which means that ALL errors are now handled instead of ignored, and they include a better description based on attribute name (e.g. `Error parsing attribute 'tilecount'). Errors inside the branch expressions are dropped for now and not displayed.