### PR TITLE
remove parent dir on external templates

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -211,7 +211,10 @@ impl ObjectData {
         // If the template attribute is there, we need to go fetch the template file
         let template = template
             .map(|template_path: String| {
-                let parent_dir = if std::fs::metadata(base_path).or(Err(Error::PathIsNotFile))?.is_file() {
+                let parent_dir = if std::fs::metadata(base_path)
+                    .or(Err(Error::PathIsNotFile))?
+                    .is_file()
+                {
                     base_path.parent().ok_or(Error::PathIsNotFile)?
                 } else {
                     base_path

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -211,7 +211,8 @@ impl ObjectData {
         // If the template attribute is there, we need to go fetch the template file
         let template = template
             .map(|template_path: String| {
-                let template_path = base_path.join(Path::new(&template_path));
+                let parent_dir = base_path.parent().ok_or(Error::PathIsNotFile)?;
+                let template_path = parent_dir.join(Path::new(&template_path));
 
                 // Check the cache to see if this template exists
                 let template = if let Some(templ) = cache.get_template(&template_path) {

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -211,8 +211,7 @@ impl ObjectData {
         // If the template attribute is there, we need to go fetch the template file
         let template = template
             .map(|template_path: String| {
-                let parent_dir = base_path.parent().ok_or(Error::PathIsNotFile)?;
-                let template_path = parent_dir.join(Path::new(&template_path));
+                let template_path = base_path.join(Path::new(&template_path));
 
                 // Check the cache to see if this template exists
                 let template = if let Some(templ) = cache.get_template(&template_path) {

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -211,7 +211,11 @@ impl ObjectData {
         // If the template attribute is there, we need to go fetch the template file
         let template = template
             .map(|template_path: String| {
-                let parent_dir = base_path.parent().ok_or(Error::PathIsNotFile)?;
+                let parent_dir = if std::fs::metadata(base_path).or(Err(Error::PathIsNotFile))?.is_file() {
+                    base_path.parent().ok_or(Error::PathIsNotFile)?
+                } else {
+                    base_path
+                };
                 let template_path = parent_dir.join(Path::new(&template_path));
 
                 // Check the cache to see if this template exists


### PR DESCRIPTION
This fixes external template loading. I'm not sure if there is another case that this isn't handling though.