### PR TITLE
Fix wangset imports

### DIFF
--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -11,7 +11,7 @@ use crate::tile::TileData;
 use crate::{util::*, Gid, Tile, TileId};
 
 mod wangset;
-pub use wangset::{WangColor, WangId, WangSet, WangTile};
+pub use wangset::*;
 
 /// A collection of tiles for usage in maps and template objects.
 ///

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -10,12 +10,13 @@ use crate::{
 };
 
 mod wang_color;
-pub use wang_color::WangColor;
+pub use wang_color::*;
 mod wang_tile;
-pub use wang_tile::{WangId, WangTile};
+pub use wang_tile::*;
 
 /// Wang set's terrain brush connection type.
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[allow(missing_docs)]
 pub enum WangSetType {
     Corner,
     Edge,

--- a/src/tileset/wangset/wang_tile.rs
+++ b/src/tileset/wangset/wang_tile.rs
@@ -8,9 +8,7 @@ use crate::{
     Result, TileId,
 };
 
-/**
-The Wang ID, stored as an array of 8 u8 values.
-*/
+/// The Wang ID, stored as an array of 8 u8 values.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct WangId(pub [u8; 8]);
 


### PR DESCRIPTION
The `WangSetType` type isn't accessible from outside and the compiler didn't complain somehow, even with the `wang_set_type` public `WangSet` member. This PR implements a fix.