### PR TITLE
Add `as_x` fns for layer types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Templates are loaded automatically when they are encountered, and are treated as
 objects. As such, `ResourceCache` has now methods for both getting and inserting them (#170).
 - Text object support (#230).
 - VFS support (#199).
+- `as_x` functions for layer types (#235).
 - `cache_mut` loader property (#207).
 
 ### Changed

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -124,10 +124,10 @@ impl MapHandler {
     ) -> HashMap<u32, Vec<SpriteBatch>> {
         let mut layer_batches: HashMap<u32, Vec<SpriteBatch>> = HashMap::new();
 
-        let tile_layers = self.map.layers().filter_map(|l| match l.layer_type() {
-            tiled::LayerType::Tiles(tl) => Some((l, tl)),
-            _ => None,
-        });
+        let tile_layers = self
+            .map
+            .layers()
+            .filter_map(|l| Some((l, l.layer_type().as_tiles()?)));
 
         for (i, (layer, tl)) in tile_layers.enumerate() {
             match &tl {

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -127,7 +127,7 @@ impl MapHandler {
         let tile_layers = self
             .map
             .layers()
-            .filter_map(|l| Some((l, l.layer_type().as_tiles()?)));
+            .filter_map(|l| Some((l, l.as_tile_layer()?)));
 
         for (i, (layer, tl)) in tile_layers.enumerate() {
             match &tl {

--- a/examples/sfml/main.rs
+++ b/examples/sfml/main.rs
@@ -43,15 +43,14 @@ impl Level {
 
         let layers = map
             .layers()
-            .filter_map(|layer| match &layer.layer_type() {
-                tiled::LayerType::Tiles(l) => Some(generate_mesh(
-                    match l {
+            .filter_map(|layer| {
+                Some(generate_mesh(
+                    match &layer.layer_type().as_tiles()? {
                         tiled::TileLayer::Finite(f) => f,
                         tiled::TileLayer::Infinite(_) => panic!("Infinite maps not supported"),
                     },
                     &tilesheet,
-                )),
-                _ => None,
+                ))
             })
             .collect();
 

--- a/examples/sfml/main.rs
+++ b/examples/sfml/main.rs
@@ -45,7 +45,7 @@ impl Level {
             .layers()
             .filter_map(|layer| {
                 Some(generate_mesh(
-                    match &layer.layer_type().as_tiles()? {
+                    match &layer.as_tile_layer()? {
                         tiled::TileLayer::Finite(f) => f,
                         tiled::TileLayer::Infinite(_) => panic!("Infinite maps not supported"),
                     },

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -177,4 +177,68 @@ impl<'map> LayerType<'map> {
             LayerDataType::Group(data) => Self::Group(GroupLayer::new(map, data)),
         }
     }
+
+    /// Casts this layer to a tile layer, only if it is one.
+    ///
+    /// Identical to:
+    /// ```ignore
+    /// match layer {
+    ///     LayerType::Tiles(x) => Some(x),
+    ///     _ => None,
+    /// }
+    /// ```
+    pub fn as_tiles(self) -> Option<TileLayer<'map>> {
+        match self {
+            Self::Tiles(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Casts this layer to an object group, only if it is one.
+    ///
+    /// Identical to:
+    /// ```ignore
+    /// match layer {
+    ///     LayerType::Objects(x) => Some(x),
+    ///     _ => None,
+    /// }
+    /// ```
+    pub fn as_objects(self) -> Option<ObjectLayer<'map>> {
+        match self {
+            Self::Objects(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Casts this layer to an image layer, only if it is one.
+    ///
+    /// Identical to:
+    /// ```ignore
+    /// match layer {
+    ///     LayerType::Image(x) => Some(x),
+    ///     _ => None,
+    /// }
+    /// ```
+    pub fn as_image(self) -> Option<ImageLayer<'map>> {
+        match self {
+            Self::Image(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Casts this layer to a group layer, only if it is one.
+    ///
+    /// Identical to:
+    /// ```ignore
+    /// match layer {
+    ///     LayerType::Group(x) => Some(x),
+    ///     _ => None,
+    /// }
+    /// ```
+    pub fn as_group(self) -> Option<GroupLayer<'map>> {
+        match self {
+            Self::Group(x) => Some(x),
+            _ => None,
+        }
+    }
 }

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -170,6 +170,74 @@ impl<'map> Layer<'map> {
     pub fn layer_type(&self) -> LayerType<'map> {
         LayerType::new(self.map, &self.data.layer_type)
     }
+
+    /// Convenience method to return this layer as a tile layer, only if it is one.
+    ///
+    /// Identical to:
+    /// ```ignore
+    /// match layer.layer_type() {
+    ///     LayerType::Tiles(x) => Some(x),
+    ///     _ => None,
+    /// }
+    /// ```
+    #[inline]
+    pub fn as_tile_layer(self) -> Option<TileLayer<'map>> {
+        match self.layer_type() {
+            LayerType::Tiles(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Convenience method to return this layer as an object group, only if it is one.
+    ///
+    /// Identical to:
+    /// ```ignore
+    /// match layer.layer_type() {
+    ///     LayerType::Objects(x) => Some(x),
+    ///     _ => None,
+    /// }
+    /// ```
+    #[inline]
+    pub fn as_object_layer(self) -> Option<ObjectLayer<'map>> {
+        match self.layer_type() {
+            LayerType::Objects(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Convenience method to return this layer as an image layer, only if it is one.
+    ///
+    /// Identical to:
+    /// ```ignore
+    /// match layer.layer_type() {
+    ///     LayerType::Image(x) => Some(x),
+    ///     _ => None,
+    /// }
+    /// ```
+    #[inline]
+    pub fn as_image_layer(self) -> Option<ImageLayer<'map>> {
+        match self.layer_type() {
+            LayerType::Image(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Convenience method to return this layer as a group layer, only if it is one.
+    ///
+    /// Identical to:
+    /// ```ignore
+    /// match layer.layer_type() {
+    ///     LayerType::Group(x) => Some(x),
+    ///     _ => None,
+    /// }
+    /// ```
+    #[inline]
+    pub fn as_group_layer(self) -> Option<GroupLayer<'map>> {
+        match self.layer_type() {
+            LayerType::Group(x) => Some(x),
+            _ => None,
+        }
+    }
 }
 
 /// Represents some kind of map layer.
@@ -192,70 +260,6 @@ impl<'map> LayerType<'map> {
             LayerDataType::Objects(data) => Self::Objects(ObjectLayer::new(map, data)),
             LayerDataType::Image(data) => Self::Image(ImageLayer::new(map, data)),
             LayerDataType::Group(data) => Self::Group(GroupLayer::new(map, data)),
-        }
-    }
-
-    /// Casts this layer to a tile layer, only if it is one.
-    ///
-    /// Identical to:
-    /// ```ignore
-    /// match layer {
-    ///     LayerType::Tiles(x) => Some(x),
-    ///     _ => None,
-    /// }
-    /// ```
-    pub fn as_tiles(self) -> Option<TileLayer<'map>> {
-        match self {
-            Self::Tiles(x) => Some(x),
-            _ => None,
-        }
-    }
-
-    /// Casts this layer to an object group, only if it is one.
-    ///
-    /// Identical to:
-    /// ```ignore
-    /// match layer {
-    ///     LayerType::Objects(x) => Some(x),
-    ///     _ => None,
-    /// }
-    /// ```
-    pub fn as_objects(self) -> Option<ObjectLayer<'map>> {
-        match self {
-            Self::Objects(x) => Some(x),
-            _ => None,
-        }
-    }
-
-    /// Casts this layer to an image layer, only if it is one.
-    ///
-    /// Identical to:
-    /// ```ignore
-    /// match layer {
-    ///     LayerType::Image(x) => Some(x),
-    ///     _ => None,
-    /// }
-    /// ```
-    pub fn as_image(self) -> Option<ImageLayer<'map>> {
-        match self {
-            Self::Image(x) => Some(x),
-            _ => None,
-        }
-    }
-
-    /// Casts this layer to a group layer, only if it is one.
-    ///
-    /// Identical to:
-    /// ```ignore
-    /// match layer {
-    ///     LayerType::Group(x) => Some(x),
-    ///     _ => None,
-    /// }
-    /// ```
-    pub fn as_group(self) -> Option<GroupLayer<'map>> {
-        match self {
-            Self::Group(x) => Some(x),
-            _ => None,
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -43,7 +43,7 @@ fn test_gzip_and_zlib_encoded_and_raw_are_the_same() {
     compare_everything_but_tileset_sources(&z, &c);
     compare_everything_but_tileset_sources(&z, &zstd);
 
-    let layer = as_finite(c.get_layer(0).unwrap().layer_type().as_tiles().unwrap());
+    let layer = as_finite(c.get_layer(0).unwrap().as_tile_layer().unwrap());
     {
         assert_eq!(layer.width(), 100);
         assert_eq!(layer.height(), 100);
@@ -101,14 +101,14 @@ fn test_infinite_map() {
         .load_tmx_map("assets/tiled_base64_zlib_infinite.tmx")
         .unwrap();
 
-    if let TileLayer::Infinite(inf) = &r.get_layer(1).unwrap().layer_type().as_tiles().unwrap() {
+    if let TileLayer::Infinite(inf) = &r.get_layer(1).unwrap().as_tile_layer().unwrap() {
         assert_eq!(inf.get_tile(2, 10).unwrap().id(), 5);
         assert_eq!(inf.get_tile(5, 36).unwrap().id(), 73);
         assert_eq!(inf.get_tile(15, 15).unwrap().id(), 22);
     } else {
         panic!("It is wrongly recognised as a finite map");
     }
-    if let TileLayer::Infinite(inf) = &r.get_layer(0).unwrap().layer_type().as_tiles().unwrap() {
+    if let TileLayer::Infinite(inf) = &r.get_layer(0).unwrap().as_tile_layer().unwrap() {
         // NW corner
         assert_eq!(inf.get_tile(-16, 0).unwrap().id(), 17);
         assert!(inf.get_tile(-17, 0).is_none());
@@ -208,7 +208,7 @@ fn test_object_group_property() {
         .load_tmx_map("assets/tiled_object_groups.tmx")
         .unwrap();
     let group_layer = r.get_layer(1).unwrap();
-    let group_layer = group_layer.layer_type().as_group().unwrap();
+    let group_layer = group_layer.as_group_layer().unwrap();
     let sub_layer = group_layer.get_layer(0).unwrap();
     let prop_value: bool = if let Some(&PropertyValue::BoolValue(ref v)) =
         sub_layer.properties.get("an object group property")
@@ -239,7 +239,7 @@ fn test_flipped() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_flipped.tmx")
         .unwrap();
-    let layer = r.get_layer(0).unwrap().layer_type().as_tiles().unwrap();
+    let layer = r.get_layer(0).unwrap().as_tile_layer().unwrap();
 
     let t1 = layer.get_tile(0, 0).unwrap();
     let t2 = layer.get_tile(1, 0).unwrap();
@@ -267,7 +267,7 @@ fn test_ldk_export() {
     let r = Loader::new()
         .load_tmx_map("assets/ldk_tiled_export.tmx")
         .unwrap();
-    let layer = as_finite(r.get_layer(0).unwrap().layer_type().as_tiles().unwrap());
+    let layer = as_finite(r.get_layer(0).unwrap().as_tile_layer().unwrap());
     {
         assert_eq!(layer.width(), 8);
         assert_eq!(layer.height(), 8);
@@ -310,8 +310,7 @@ fn test_object_property() {
         .unwrap();
     let layer = r.get_layer(1).unwrap();
     let prop_value = if let Some(PropertyValue::ObjectValue(v)) = layer
-        .layer_type()
-        .as_objects()
+        .as_object_layer()
         .unwrap()
         .get_object(0)
         .unwrap()
@@ -380,9 +379,9 @@ fn test_group_layers() {
     );
 
     // Depth = 1
-    let layer_group_1 = layer_group_1.layer_type().as_group().unwrap();
+    let layer_group_1 = layer_group_1.as_group_layer().unwrap();
     let layer_tile_2 = layer_group_1.get_layer(0).unwrap();
-    let layer_group_2 = layer_group_2.layer_type().as_group().unwrap();
+    let layer_group_2 = layer_group_2.as_group_layer().unwrap();
     let layer_group_3 = layer_group_2.get_layer(0).unwrap();
     assert_eq!(
         Some(&PropertyValue::StringValue("value2".to_string())),
@@ -394,7 +393,7 @@ fn test_group_layers() {
     );
 
     // Depth = 2
-    let layer_group_3 = layer_group_3.layer_type().as_group().unwrap();
+    let layer_group_3 = layer_group_3.as_group_layer().unwrap();
     let layer_tile_3 = layer_group_3.get_layer(0).unwrap();
     assert_eq!(
         Some(&PropertyValue::StringValue("value3".to_string())),
@@ -408,7 +407,7 @@ fn test_object_template_property() {
         .load_tmx_map("assets/tiled_object_template.tmx")
         .unwrap();
 
-    let object_layer = r.get_layer(1).unwrap().layer_type().as_objects().unwrap();
+    let object_layer = r.get_layer(1).unwrap().as_object_layer().unwrap();
     let object = object_layer.get_object(0).unwrap(); // The templated object
     let object_nt = object_layer.get_object(1).unwrap(); // The non-templated object
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,31 +4,10 @@ use tiled::{
     PropertyValue, ResourceCache, TileLayer, TilesetLocation, WangId,
 };
 
-fn as_tile_layer<'map>(layer: Layer<'map>) -> TileLayer<'map> {
-    match layer.layer_type() {
-        LayerType::Tiles(x) => x,
-        _ => panic!("Not a tile layer"),
-    }
-}
-
 fn as_finite<'map>(data: TileLayer<'map>) -> FiniteTileLayer<'map> {
     match data {
         TileLayer::Finite(data) => data,
         TileLayer::Infinite(_) => panic!("Not a finite tile layer"),
-    }
-}
-
-fn as_object_layer<'map>(layer: Layer<'map>) -> ObjectLayer<'map> {
-    match layer.layer_type() {
-        LayerType::Objects(x) => x,
-        _ => panic!("Not an object layer"),
-    }
-}
-
-fn as_group_layer<'map>(layer: Layer<'map>) -> GroupLayer<'map> {
-    match layer.layer_type() {
-        LayerType::Group(x) => x,
-        _ => panic!("Not a group layer"),
     }
 }
 
@@ -64,7 +43,7 @@ fn test_gzip_and_zlib_encoded_and_raw_are_the_same() {
     compare_everything_but_tileset_sources(&z, &c);
     compare_everything_but_tileset_sources(&z, &zstd);
 
-    let layer = as_finite(as_tile_layer(c.get_layer(0).unwrap()));
+    let layer = as_finite(c.get_layer(0).unwrap().layer_type().as_tiles().unwrap());
     {
         assert_eq!(layer.width(), 100);
         assert_eq!(layer.height(), 100);
@@ -122,14 +101,14 @@ fn test_infinite_map() {
         .load_tmx_map("assets/tiled_base64_zlib_infinite.tmx")
         .unwrap();
 
-    if let TileLayer::Infinite(inf) = &as_tile_layer(r.get_layer(1).unwrap()) {
+    if let TileLayer::Infinite(inf) = &r.get_layer(1).unwrap().layer_type().as_tiles().unwrap() {
         assert_eq!(inf.get_tile(2, 10).unwrap().id(), 5);
         assert_eq!(inf.get_tile(5, 36).unwrap().id(), 73);
         assert_eq!(inf.get_tile(15, 15).unwrap().id(), 22);
     } else {
         panic!("It is wrongly recognised as a finite map");
     }
-    if let TileLayer::Infinite(inf) = &as_tile_layer(r.get_layer(0).unwrap()) {
+    if let TileLayer::Infinite(inf) = &r.get_layer(0).unwrap().layer_type().as_tiles().unwrap() {
         // NW corner
         assert_eq!(inf.get_tile(-16, 0).unwrap().id(), 17);
         assert!(inf.get_tile(-17, 0).is_none());
@@ -229,7 +208,7 @@ fn test_object_group_property() {
         .load_tmx_map("assets/tiled_object_groups.tmx")
         .unwrap();
     let group_layer = r.get_layer(1).unwrap();
-    let group_layer = as_group_layer(group_layer);
+    let group_layer = group_layer.layer_type().as_group().unwrap();
     let sub_layer = group_layer.get_layer(0).unwrap();
     let prop_value: bool = if let Some(&PropertyValue::BoolValue(ref v)) =
         sub_layer.properties.get("an object group property")
@@ -260,7 +239,7 @@ fn test_flipped() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_flipped.tmx")
         .unwrap();
-    let layer = as_tile_layer(r.get_layer(0).unwrap());
+    let layer = r.get_layer(0).unwrap().layer_type().as_tiles().unwrap();
 
     let t1 = layer.get_tile(0, 0).unwrap();
     let t2 = layer.get_tile(1, 0).unwrap();
@@ -288,7 +267,7 @@ fn test_ldk_export() {
     let r = Loader::new()
         .load_tmx_map("assets/ldk_tiled_export.tmx")
         .unwrap();
-    let layer = as_finite(as_tile_layer(r.get_layer(0).unwrap()));
+    let layer = as_finite(r.get_layer(0).unwrap().layer_type().as_tiles().unwrap());
     {
         assert_eq!(layer.width(), 8);
         assert_eq!(layer.height(), 8);
@@ -330,7 +309,10 @@ fn test_object_property() {
         .load_tmx_map("assets/tiled_object_property.tmx")
         .unwrap();
     let layer = r.get_layer(1).unwrap();
-    let prop_value = if let Some(PropertyValue::ObjectValue(v)) = as_object_layer(layer)
+    let prop_value = if let Some(PropertyValue::ObjectValue(v)) = layer
+        .layer_type()
+        .as_objects()
+        .unwrap()
         .get_object(0)
         .unwrap()
         .properties
@@ -398,9 +380,9 @@ fn test_group_layers() {
     );
 
     // Depth = 1
-    let layer_group_1 = as_group_layer(layer_group_1);
+    let layer_group_1 = layer_group_1.layer_type().as_group().unwrap();
     let layer_tile_2 = layer_group_1.get_layer(0).unwrap();
-    let layer_group_2 = as_group_layer(layer_group_2);
+    let layer_group_2 = layer_group_2.layer_type().as_group().unwrap();
     let layer_group_3 = layer_group_2.get_layer(0).unwrap();
     assert_eq!(
         Some(&PropertyValue::StringValue("value2".to_string())),
@@ -412,7 +394,7 @@ fn test_group_layers() {
     );
 
     // Depth = 2
-    let layer_group_3 = as_group_layer(layer_group_3);
+    let layer_group_3 = layer_group_3.layer_type().as_group().unwrap();
     let layer_tile_3 = layer_group_3.get_layer(0).unwrap();
     assert_eq!(
         Some(&PropertyValue::StringValue("value3".to_string())),
@@ -426,7 +408,7 @@ fn test_object_template_property() {
         .load_tmx_map("assets/tiled_object_template.tmx")
         .unwrap();
 
-    let object_layer = as_object_layer(r.get_layer(1).unwrap());
+    let object_layer = r.get_layer(1).unwrap().layer_type().as_objects().unwrap();
     let object = object_layer.get_object(0).unwrap(); // The templated object
     let object_nt = object_layer.get_object(1).unwrap(); // The non-templated object
 


### PR DESCRIPTION
Improves crate ergonomics. Most of the time when parsing you are only interested in one layer type at a time so it's much nicer to use `layer.layer_type().as_tiles()` than the whole match block. Specially nice for closures in filters:
```rs
// Old
let tile_layers = self
    .map
    .layers()
    .filter_map(|l|
        match l.layer_type() {
            tiled::LayerType::Tiles(tl) => Some((l, tl)),
            _ => None,
        }
    );

// New
let tile_layers = self
    .map
    .layers()
    .filter_map(|l| Some((l, l.layer_type().as_tiles()?)));
```
Crates like [serde_json](https://docs.rs/serde_json/latest/serde_json/enum.Value.html) do this with some of their enums.
