### PR TITLE
Support Tiled 1.9 `class` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for Wang sets.
+- Support for Tiled 1.9+ `class` property.
 
 ### Changed
 - Update `zstd` to `0.12.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for Wang sets.
-- Support for Tiled 1.9+ `class` property.
+- Support for Tiled 1.9 `Class` property. Maps, tilesets and layers now have a `user_type` property. 
+
+### Deprecated
+- `Tile::tile_type`: Use `Tile::user_type` instead.
+- `Object::obj_type` Use `Object::user_type` instead.
 
 ### Changed
 - Update `zstd` to `0.12.0`.

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -52,7 +52,7 @@ pub struct LayerData {
     /// The layer's custom properties, as arbitrarily set by the user.
     pub properties: Properties,
     /// The layer's type, which is arbitrarily setby the user.
-    pub user_type: String,
+    pub user_type: Option<String>,
     layer_type: LayerDataType,
 }
 
@@ -83,6 +83,7 @@ impl LayerData {
             name,
             id,
             user_type,
+            user_class,
         ) = get_attrs!(
             for v in attrs {
                 Some("opacity") => opacity ?= v.parse(),
@@ -94,9 +95,10 @@ impl LayerData {
                 Some("parallaxy") => parallax_y ?= v.parse(),
                 Some("name") => name = v,
                 Some("id") => id ?= v.parse(),
-                Some("class") => user_type ?= v.parse(),
+                Some("type") => user_type ?= v.parse(),
+                Some("class") => user_class ?= v.parse(),
             }
-            (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type)
+            (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type, user_class)
         );
 
         let (ty, properties) = match tag {
@@ -128,7 +130,7 @@ impl LayerData {
             tint_color,
             name: name.unwrap_or_default(),
             id: id.unwrap_or(0),
-            user_type: user_type.unwrap_or_default(),
+            user_type: user_type.or(user_class),
             properties,
             layer_type: ty,
         })

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -51,6 +51,8 @@ pub struct LayerData {
     pub tint_color: Option<Color>,
     /// The layer's custom properties, as arbitrarily set by the user.
     pub properties: Properties,
+    /// The layer's type, which is arbitrarily setby the user.
+    pub user_type: String,
     layer_type: LayerDataType,
 }
 
@@ -70,7 +72,18 @@ impl LayerData {
         map_path: &Path,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
-        let (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id) = get_attrs!(
+        let (
+            opacity,
+            tint_color,
+            visible,
+            offset_x,
+            offset_y,
+            parallax_x,
+            parallax_y,
+            name,
+            id,
+            user_type,
+        ) = get_attrs!(
             for v in attrs {
                 Some("opacity") => opacity ?= v.parse(),
                 Some("tintcolor") => tint_color ?= v.parse(),
@@ -81,8 +94,9 @@ impl LayerData {
                 Some("parallaxy") => parallax_y ?= v.parse(),
                 Some("name") => name = v,
                 Some("id") => id ?= v.parse(),
+                Some("class") => user_type ?= v.parse(),
             }
-            (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id)
+            (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type)
         );
 
         let (ty, properties) = match tag {
@@ -114,6 +128,7 @@ impl LayerData {
             tint_color,
             name: name.unwrap_or_default(),
             id: id.unwrap_or(0),
+            user_type: user_type.unwrap_or_default(),
             properties,
             layer_type: ty,
         })

--- a/src/map.rs
+++ b/src/map.rs
@@ -57,6 +57,8 @@ pub struct Map {
     /// The background color of this map, if any.
     pub background_color: Option<Color>,
     infinite: bool,
+    /// The type of the map, which is arbitrary and set by the user.
+    pub map_type: String,
 }
 
 impl Map {
@@ -157,10 +159,11 @@ impl Map {
         map_path: &Path,
         cache: &mut impl ResourceCache,
     ) -> Result<Map> {
-        let ((c, infinite), (v, o, w, h, tw, th)) = get_attrs!(
+        let ((c, infinite, user_type), (v, o, w, h, tw, th)) = get_attrs!(
             for v in attrs {
                 Some("backgroundcolor") => colour ?= v.parse(),
                 Some("infinite") => infinite = v == "1",
+                Some("class") => user_type ?= v.parse(),
                 "version" => version = v,
                 "orientation" => orientation ?= v.parse::<Orientation>(),
                 "width" => width ?= v.parse::<u32>(),
@@ -168,10 +171,11 @@ impl Map {
                 "tilewidth" => tile_width ?= v.parse::<u32>(),
                 "tileheight" => tile_height ?= v.parse::<u32>(),
             }
-            ((colour, infinite), (version, orientation, width, height, tile_width, tile_height))
+            ((colour, infinite, user_type), (version, orientation, width, height, tile_width, tile_height))
         );
 
         let infinite = infinite.unwrap_or(false);
+        let map_type = user_type.unwrap_or_default();
 
         // We can only parse sequentally, but tilesets are guaranteed to appear before layers.
         // So we can pass in tileset data to layer construction without worrying about unfinished
@@ -260,6 +264,7 @@ impl Map {
             properties,
             background_color: c,
             infinite,
+            map_type,
         })
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -58,7 +58,7 @@ pub struct Map {
     pub background_color: Option<Color>,
     infinite: bool,
     /// The type of the map, which is arbitrary and set by the user.
-    pub map_type: String,
+    pub user_type: Option<String>,
 }
 
 impl Map {
@@ -159,11 +159,12 @@ impl Map {
         map_path: &Path,
         cache: &mut impl ResourceCache,
     ) -> Result<Map> {
-        let ((c, infinite, user_type), (v, o, w, h, tw, th)) = get_attrs!(
+        let ((c, infinite, user_type, user_class), (v, o, w, h, tw, th)) = get_attrs!(
             for v in attrs {
                 Some("backgroundcolor") => colour ?= v.parse(),
                 Some("infinite") => infinite = v == "1",
-                Some("class") => user_type ?= v.parse(),
+                Some("type") => user_type ?= v.parse(),
+                Some("class") => user_class ?= v.parse(),
                 "version" => version = v,
                 "orientation" => orientation ?= v.parse::<Orientation>(),
                 "width" => width ?= v.parse::<u32>(),
@@ -171,11 +172,11 @@ impl Map {
                 "tilewidth" => tile_width ?= v.parse::<u32>(),
                 "tileheight" => tile_height ?= v.parse::<u32>(),
             }
-            ((colour, infinite, user_type), (version, orientation, width, height, tile_width, tile_height))
+            ((colour, infinite, user_type, user_class), (version, orientation, width, height, tile_width, tile_height))
         );
 
         let infinite = infinite.unwrap_or(false);
-        let map_type = user_type.unwrap_or_default();
+        let user_type = user_type.or(user_class);
 
         // We can only parse sequentally, but tilesets are guaranteed to appear before layers.
         // So we can pass in tileset data to layer construction without worrying about unfinished
@@ -264,7 +265,7 @@ impl Map {
             properties,
             background_color: c,
             infinite,
-            map_type,
+            user_type,
         })
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -34,7 +34,7 @@ pub struct ObjectData {
     /// The type of the object, which is arbitrary and set by the user.
     pub user_type: String,
     /// This property has been renamed to `user_type`.
-    #[deprecated(since = "0.11.0", note = "Use [`ObjectData::user_type`] instead")]
+    #[deprecated(since = "0.10.3", note = "Use [`ObjectData::user_type`] instead")]
     pub obj_type: String,
     /// The width of the object, if applicable. This refers to the attribute in `object`.
     /// Since it is duplicate or irrelevant information in all cases, use the equivalent

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -32,6 +32,9 @@ pub struct ObjectData {
     /// The name of the object, which is arbitrary and set by the user.
     pub name: String,
     /// The type of the object, which is arbitrary and set by the user.
+    pub user_type: String,
+    /// This property has been renamed to `user_type`.
+    #[deprecated(since = "0.11.0", note = "Use [`ObjectData::user_type`] instead")]
     pub obj_type: String,
     /// The width of the object, if applicable. This refers to the attribute in `object`.
     /// Since it is duplicate or irrelevant information in all cases, use the equivalent
@@ -86,8 +89,8 @@ impl ObjectData {
                 Some("id") => id ?= v.parse(),
                 Some("gid") => tile ?= v.parse(),
                 Some("name") => name ?= v.parse(),
-                Some("type") => obj_type ?= v.parse(),
-                Some("class") => obj_class ?= v.parse(),
+                Some("type") => user_type ?= v.parse(),
+                Some("class") => user_class ?= v.parse(),
                 Some("width") => width ?= v.parse(),
                 Some("height") => height ?= v.parse(),
                 Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
@@ -96,9 +99,8 @@ impl ObjectData {
                 "x" => x ?= v.parse::<f32>(),
                 "y" => y ?= v.parse::<f32>(),
             }
-            ((id, tile, name, obj_type, obj_class, width, height, visible, rotation), (x, y))
+            ((id, tile, name, user_type, user_class, width, height, visible, rotation), (x, y))
         );
-        let t = t.or(c);
         let tile = tile.and_then(|bits| LayerTileData::from_bits(bits, tilesets?));
         let visible = v.unwrap_or(true);
         let width = w.unwrap_or(0f32);
@@ -106,7 +108,7 @@ impl ObjectData {
         let rotation = r.unwrap_or(0f32);
         let id = id.unwrap_or(0u32);
         let name = n.unwrap_or_default();
-        let obj_type = t.unwrap_or_default();
+        let user_type: String = t.or(c).unwrap_or_default();
         let mut shape = None;
         let mut properties = HashMap::new();
 
@@ -143,7 +145,8 @@ impl ObjectData {
             id,
             tile,
             name,
-            obj_type,
+            obj_type: user_type.clone(),
+            user_type,
             width,
             height,
             x,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -81,12 +81,13 @@ impl ObjectData {
         attrs: Vec<OwnedAttribute>,
         tilesets: Option<&[MapTilesetGid]>,
     ) -> Result<ObjectData> {
-        let ((id, tile, n, t, w, h, v, r), (x, y)) = get_attrs!(
+        let ((id, tile, n, t, c, w, h, v, r), (x, y)) = get_attrs!(
             for v in attrs {
                 Some("id") => id ?= v.parse(),
                 Some("gid") => tile ?= v.parse(),
                 Some("name") => name ?= v.parse(),
                 Some("type") => obj_type ?= v.parse(),
+                Some("class") => obj_class ?= v.parse(),
                 Some("width") => width ?= v.parse(),
                 Some("height") => height ?= v.parse(),
                 Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
@@ -95,8 +96,9 @@ impl ObjectData {
                 "x" => x ?= v.parse::<f32>(),
                 "y" => y ?= v.parse::<f32>(),
             }
-            ((id, tile, name, obj_type, width, height, visible, rotation), (x, y))
+            ((id, tile, name, obj_type, obj_class, width, height, visible, rotation), (x, y))
         );
+        let t = t.or(c);
         let tile = tile.and_then(|bits| LayerTileData::from_bits(bits, tilesets?));
         let visible = v.unwrap_or(true);
         let width = w.unwrap_or(0f32);

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -27,6 +27,9 @@ pub struct TileData {
     /// The animation frames of this tile.
     pub animation: Option<Vec<Frame>>,
     /// The type of this tile.
+    pub user_type: Option<String>,
+    /// This property has been renamed to `user_type`.
+    #[deprecated(since = "0.11.0", note = "Use [`TileData::user_type`] instead")]
     pub tile_type: Option<String>,
     /// The probability of this tile.
     pub probability: f32,
@@ -65,16 +68,16 @@ impl TileData {
         attrs: Vec<OwnedAttribute>,
         path_relative_to: &Path,
     ) -> Result<(TileId, TileData)> {
-        let ((tile_type, tile_class, probability), id) = get_attrs!(
+        let ((user_type, user_class, probability), id) = get_attrs!(
             for v in attrs {
-                Some("type") => tile_type ?= v.parse(),
-                Some("class") => tile_class ?= v.parse(),
+                Some("type") => user_type ?= v.parse(),
+                Some("class") => user_class ?= v.parse(),
                 Some("probability") => probability ?= v.parse(),
                 "id" => id ?= v.parse::<u32>(),
             }
-            ((tile_type, tile_class, probability), id)
+            ((user_type, user_class, probability), id)
         );
-        let tile_type = tile_type.or(tile_class);
+        let user_type = user_type.or(user_class);
         let mut image = Option::None;
         let mut properties = HashMap::new();
         let mut objectgroup = None;
@@ -99,12 +102,14 @@ impl TileData {
         });
         Ok((
             id,
+            #[allow(deprecated)]
             TileData {
                 image,
                 properties,
                 collision: objectgroup,
                 animation,
-                tile_type,
+                tile_type: user_type.clone(),
+                user_type,
                 probability: probability.unwrap_or(1.0),
             },
         ))

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -65,15 +65,16 @@ impl TileData {
         attrs: Vec<OwnedAttribute>,
         path_relative_to: &Path,
     ) -> Result<(TileId, TileData)> {
-        let ((tile_type, probability), id) = get_attrs!(
+        let ((tile_type, tile_class, probability), id) = get_attrs!(
             for v in attrs {
                 Some("type") => tile_type ?= v.parse(),
+                Some("class") => tile_class ?= v.parse(),
                 Some("probability") => probability ?= v.parse(),
                 "id" => id ?= v.parse::<u32>(),
             }
-            ((tile_type, probability), id)
+            ((tile_type, tile_class, probability), id)
         );
-
+        let tile_type = tile_type.or(tile_class);
         let mut image = Option::None;
         let mut properties = HashMap::new();
         let mut objectgroup = None;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -29,7 +29,7 @@ pub struct TileData {
     /// The type of this tile.
     pub user_type: Option<String>,
     /// This property has been renamed to `user_type`.
-    #[deprecated(since = "0.11.0", note = "Use [`TileData::user_type`] instead")]
+    #[deprecated(since = "0.10.3", note = "Use [`TileData::user_type`] instead")]
     pub tile_type: Option<String>,
     /// The probability of this tile.
     pub probability: f32,


### PR DESCRIPTION
### Why

Closes #234 

In Tiled 1.9 the "type" property was renamed to "class". My PR addresses this.

### How

In addition to "type", the "class" property is parsed. If the former is not present, the latter takes its place. This way, the solution is compatible with both 1.9+ and older maps. 

After the below conversation, this is what I did:
- Deprecated `obj_type` for Objects and `tile_type` for Tiles in favor of `user_type`. Added deprecation notices
- Added `user_type` to Maps, Tilesets and Layers.
- Both `class` and `type` XML params now resolve to `user_type` everywhere.

Support for type/class is now implemented for the following entities:
- Tiles in tileset (`Tile`)
- Objects
- Maps
- Tilesets
- Layers

These are all places that I'm aware of.

### Test plan

Tested locally on both old and new maps.
I didn't add tests as I haven't found any existing ones (nor test fixtures) which have the "type" or "class" property set. Eventually, I can create/modify one if requested. 