### PR TITLE
Revert breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for tile offsets. Tilesets now have an `offset_x` and `offset_y` property.
 
 ### Deprecated
-- `Tile::tile_type`: Use `Tile::user_type` instead.
 - `Object::obj_type` Use `Object::user_type` instead.
 
 ### Changed

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -27,9 +27,8 @@ pub struct TileData {
     /// The animation frames of this tile.
     pub animation: Option<Vec<Frame>>,
     /// The type of this tile.
-    pub user_type: Option<String>,
-    /// This property has been renamed to `user_type`.
-    #[deprecated(since = "0.10.3", note = "Use [`TileData::user_type`] instead")]
+    // TODO(0.11.0): Rename to `user_type` (https://github.com/mapeditor/rs-tiled/pull/238, postponed because of
+    // breaking change)
     pub tile_type: Option<String>,
     /// The probability of this tile.
     pub probability: f32,
@@ -108,8 +107,7 @@ impl TileData {
                 properties,
                 collision: objectgroup,
                 animation,
-                tile_type: user_type.clone(),
-                user_type,
+                tile_type: user_type,
                 probability: probability.unwrap_or(1.0),
             },
         ))


### PR DESCRIPTION
Reverts adding `TileData::user_type` (From https://github.com/mapeditor/rs-tiled/pull/238), preventing a breaking change from adding a new member to an all public structure.