### PR TITLE
Updated lifetime of LayerTile returned from TileLayer

### DIFF
--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -85,7 +85,7 @@ impl<'map> FiniteTileLayer<'map> {
     /// Obtains the tile present at the position given.
     ///
     /// If the position given is invalid or the position is empty, this function will return [`None`].
-    pub fn get_tile(&self, x: i32, y: i32) -> Option<LayerTile> {
+    pub fn get_tile(&self, x: i32, y: i32) -> Option<LayerTile<'map>> {
         self.data
             .get_tile_data(x, y)
             .map(|data| LayerTile::new(self.map(), data))

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -221,7 +221,7 @@ impl<'map> InfiniteTileLayer<'map> {
     /// Obtains the tile present at the position given.
     ///
     /// If the position is empty, this function will return [`None`].
-    pub fn get_tile(&self, x: i32, y: i32) -> Option<LayerTile> {
+    pub fn get_tile(&self, x: i32, y: i32) -> Option<LayerTile<'map>> {
         self.data
             .get_tile_data(x, y)
             .map(|data| LayerTile::new(self.map, data))

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -167,7 +167,7 @@ impl<'map> TileLayer<'map> {
     /// Obtains the tile present at the position given.
     ///
     /// If the position given is invalid or the position is empty, this function will return [`None`].
-    pub fn get_tile(&self, x: i32, y: i32) -> Option<LayerTile> {
+    pub fn get_tile(&self, x: i32, y: i32) -> Option<LayerTile<'map>> {
         match self {
             TileLayer::Finite(finite) => finite.get_tile(x, y),
             TileLayer::Infinite(infinite) => infinite.get_tile(x, y),


### PR DESCRIPTION
Small PR to change the lifetime specifier of the LayerTile returned by the get_tile methods.
Previously, the LayerTile returned by these methods would have the elided lifetime of "self", which is shorter than 'map.