### PR TITLE
Add content to text shape, fix kerning default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased (next)]
 ### Added
+- Add `contents` member to `ObjectShape::Text`. (#278)
 - Implement `ResourceReader` for appropiate functions. (#272) **Read the README's FAQ for more information about this change.**
+
+## Fixed
+- `ObjectShape::Text::kerning`'s default value, which should have been set to `true` instead of `false`. (#278)
 
 ## [Unreleased]
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased (next)]
 ### Added
-- Add `contents` member to `ObjectShape::Text`. (#278)
+- Add `text`, `width` and `height` members to `ObjectShape::Text`. (#278)
 - Implement `ResourceReader` for appropiate functions. (#272) **Read the README's FAQ for more information about this change.**
 
 ## Fixed

--- a/assets/tiled_text_object.tmx
+++ b/assets/tiled_text_object.tmx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="1" height="1" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="2">
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="1" x="-24.1094" y="-2.39844" width="87.7188" height="21.7969">
+   <text color="#6455ff7f" bold="1" italic="1" underline="1" strikeout="1" halign="center" valign="bottom">Test</text>
+  </object>
+ </objectgroup>
+</map>

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -149,6 +149,8 @@ pub enum ObjectShape {
         valign: VerticalAlignment,
         /// The actual text content of this object.
         text: String,
+        width: f32,
+        height: f32,
     },
 }
 
@@ -308,7 +310,7 @@ impl ObjectData {
                 Ok(())
             },
             "text" => |attrs| {
-                shape = Some(ObjectData::new_text(attrs, parser)?);
+                shape = Some(ObjectData::new_text(attrs, parser, width, height)?);
                 Ok(())
             },
             "properties" => |_| {
@@ -370,6 +372,8 @@ impl ObjectData {
     fn new_text(
         attrs: Vec<OwnedAttribute>,
         parser: &mut impl Iterator<Item = XmlEventResult>,
+        width: f32,
+        height: f32,
     ) -> Result<ObjectShape> {
         let (
             font_family,
@@ -466,6 +470,8 @@ impl ObjectData {
             halign,
             valign,
             text: contents,
+            width,
+            height,
         })
     }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -148,7 +148,7 @@ pub enum ObjectShape {
         halign: HorizontalAlignment,
         valign: VerticalAlignment,
         /// The actual text content of this object.
-        contents: String,
+        text: String,
     },
 }
 
@@ -465,7 +465,7 @@ impl ObjectData {
             kerning,
             halign,
             valign,
-            contents,
+            text: contents,
         })
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -516,7 +516,7 @@ fn test_text_object() {
             kerning,
             halign,
             valign,
-            contents,
+            text,
         } => {
             assert_eq!(font_family.as_str(), "sans-serif");
             assert_eq!(*pixel_size, 16);
@@ -537,7 +537,7 @@ fn test_text_object() {
             assert_eq!(*kerning, true);
             assert_eq!(*halign, HorizontalAlignment::Center);
             assert_eq!(*valign, VerticalAlignment::Bottom);
-            assert_eq!(contents.as_str(), "Test");
+            assert_eq!(text.as_str(), "Test");
         }
         _ => panic!(),
     };

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -517,6 +517,8 @@ fn test_text_object() {
             halign,
             valign,
             text,
+            width,
+            height,
         } => {
             assert_eq!(font_family.as_str(), "sans-serif");
             assert_eq!(*pixel_size, 16);
@@ -538,6 +540,8 @@ fn test_text_object() {
             assert_eq!(*halign, HorizontalAlignment::Center);
             assert_eq!(*valign, VerticalAlignment::Bottom);
             assert_eq!(text.as_str(), "Test");
+            assert_eq!(*width, 87.7188);
+            assert_eq!(*height, 21.7969);
         }
         _ => panic!(),
     };

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 use tiled::{
-    Color, FiniteTileLayer, GroupLayer, Layer, LayerType, Loader, Map, ObjectLayer, ObjectShape,
-    PropertyValue, ResourceCache, TileLayer, TilesetLocation, WangId,
+    Color, FiniteTileLayer, GroupLayer, HorizontalAlignment, Layer, LayerType, Loader, Map,
+    ObjectLayer, ObjectShape, PropertyValue, ResourceCache, TileLayer, TilesetLocation,
+    VerticalAlignment, WangId,
 };
 
 fn as_finite<'map>(data: TileLayer<'map>) -> FiniteTileLayer<'map> {
@@ -494,4 +495,50 @@ fn test_reading_wang_sets() {
     let readed_damage = color_2.properties.get("Damage").unwrap();
     let damage_value = &PropertyValue::FloatValue(32.1);
     assert_eq!(readed_damage, damage_value);
+}
+
+#[test]
+fn test_text_object() {
+    let mut loader = Loader::new();
+    let map = loader.load_tmx_map("assets/tiled_text_object.tmx").unwrap();
+
+    let group = map.get_layer(0).unwrap().as_object_layer().unwrap();
+    match &group.objects().next().unwrap().shape {
+        ObjectShape::Text {
+            font_family,
+            pixel_size,
+            wrap,
+            color,
+            bold,
+            italic,
+            underline,
+            strikeout,
+            kerning,
+            halign,
+            valign,
+            contents,
+        } => {
+            assert_eq!(font_family.as_str(), "sans-serif");
+            assert_eq!(*pixel_size, 16);
+            assert_eq!(*wrap, false);
+            assert_eq!(
+                *color,
+                Color {
+                    red: 85,
+                    green: 255,
+                    blue: 127,
+                    alpha: 100
+                }
+            );
+            assert_eq!(*bold, true);
+            assert_eq!(*italic, true);
+            assert_eq!(*underline, true);
+            assert_eq!(*strikeout, true);
+            assert_eq!(*kerning, true);
+            assert_eq!(*halign, HorizontalAlignment::Center);
+            assert_eq!(*valign, VerticalAlignment::Bottom);
+            assert_eq!(contents.as_str(), "Test");
+        }
+        _ => panic!(),
+    };
 }


### PR DESCRIPTION
Somehow when adding text objects I forgot the most important thing of them: Their content. So there is currently no way to see the content of an object with the Text shape. I'm sorry for that. Sadly this change is breaking so it won't be featured until 0.12, but I'm considering releasing it just because of this.
Also fixes `kerning`'s default value, which should be `true`. (https://docs.mapeditor.org/en/latest/reference/tmx-map-format/#text)