### PR TITLE
Update version & libflate dep to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## Changed
 - Updated `Image` docs. (#270)
+- Update `libflate` dependency to `2.0.0`.
 - Fix some doc links. (#273)
 - Update ggez example to 0.9.3.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.2]
 ## Changed
 - Updated `Image` docs. (#270)
-- Update `libflate` dependency to `2.0.0`.
+- Update `libflate` dependency to `2.0.0`. (#279)
 - Fix some doc links. (#273)
 - Update ggez example to 0.9.3.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiled"
-version = "0.11.1"
+version = "0.11.2"
 description = "A rust crate for loading maps created by the Tiled editor"
 categories = ["game-development"]
 keywords = ["gamedev", "tiled", "tmx", "map"]
@@ -34,7 +34,7 @@ path = "examples/ggez/main.rs"
 [dependencies]
 base64 = "0.21.0"
 xml-rs = "0.8.4"
-libflate = "1.1.2"
+libflate = "2.0.0"
 zstd = { version = "0.12.0", optional = true, default-features = false }
 
 [dev-dependencies.sfml]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rs-tiled
 ```toml
-tiled = "0.11.1"
+tiled = "0.11.2"
 ```
 
 [![Rust](https://github.com/mapeditor/rs-tiled/actions/workflows/rust.yml/badge.svg)](https://github.com/mapeditor/rs-tiled/actions/workflows/rust.yml)


### PR DESCRIPTION
Updates the crate version for a new crates.io release and updates the libflate dependency. I tried to update the SFML dependency as well but it wasn't trivial as there were C++ build errors so I decided to leave it for another PR.