### PR TITLE
replace libflate with flate2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3]
+## Changed
+- Replace `libflate` with `flate2`. (#281)
+
 ## [0.11.2]
 ## Changed
 - Updated `Image` docs. (#270)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiled"
-version = "0.11.2"
+version = "0.11.3"
 description = "A rust crate for loading maps created by the Tiled editor"
 categories = ["game-development"]
 keywords = ["gamedev", "tiled", "tmx", "map"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/ggez/main.rs"
 [dependencies]
 base64 = "0.21.0"
 xml-rs = "0.8.4"
-libflate = "2.0.0"
+flate2 = "1.0.28"
 zstd = { version = "0.12.0", optional = true, default-features = false }
 
 [dev-dependencies.sfml]

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -16,10 +16,10 @@ pub(crate) fn parse_data_line(
 
         (Some("base64"), None) => parse_base64(parser).map(|v| convert_to_tiles(&v, tilesets)),
         (Some("base64"), Some("zlib")) => parse_base64(parser)
-            .and_then(|data| process_decoder(libflate::zlib::Decoder::new(&data[..])))
+            .and_then(|data| process_decoder(Ok(flate2::bufread::ZlibDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
         (Some("base64"), Some("gzip")) => parse_base64(parser)
-            .and_then(|data| process_decoder(libflate::gzip::Decoder::new(&data[..])))
+            .and_then(|data| process_decoder(Ok(flate2::bufread::GzDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
         #[cfg(feature = "zstd")]
         (Some("base64"), Some("zstd")) => parse_base64(parser)


### PR DESCRIPTION
Initially `rs-tiled` used `flate2` but switched to `libflate` because `flate2` didn't support wasm https://github.com/mapeditor/rs-tiled/issues/47 , but `flate2` has been supporting wasm via `miniz_oxide` for a while now https://github.com/rust-lang/flate2-rs/issues/161.

This reduces dependency duplicated by other crates and has performance benefits.