### PR TITLE
Support for class properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.11.3]
+### Added
+- Support for custom type properties. (#282)
 ## Changed
 - Replace `libflate` with `flate2`. (#281)
 

--- a/assets/tiled_class_property.tmx
+++ b/assets/tiled_class_property.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="4">
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="4">
  <layer id="1" name="Tile Layer 1" width="2" height="2">
   <data encoding="csv">
 0,0,
@@ -11,7 +11,7 @@
    <properties>
     <property name="class property" type="class" propertytype="test_type">
      <properties>
-      <property name="test_property_1" value="3" type="int"/>
+      <property name="test_property_1" type="int" value="3"/>
      </properties>
     </property>
     <property name="empty property" type="class" propertytype="empty_type"/>

--- a/assets/tiled_class_property.tmx
+++ b/assets/tiled_class_property.tmx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="4">
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="2" x="0" y="0" width="32" height="32">
+   <properties>
+    <property name="class property" type="class" propertytype="test_type">
+     <properties>
+      <property name="test_property_1" value="3" type="int"/>
+     </properties>
+    </property>
+    <property name="empty property" type="class" propertytype="empty_type"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -163,7 +163,7 @@ pub(crate) fn parse_properties(
                     HashMap::new()
                 };
                 p.insert(k, PropertyValue::ClassValue {
-                    property_type: p_t.unwrap_or_else(|| "class".to_owned()),
+                    property_type: p_t.unwrap_or_default(),
                     properties,
                 });
                 return Ok(());

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -82,6 +82,14 @@ pub enum PropertyValue {
     /// An object ID value. Corresponds to the `object` property type.
     /// Holds the id of a referenced object, or 0 if unset.
     ObjectValue(u32),
+    /// A class value. Corresponds to the `class` property type.
+    /// Holds the type name and a set of properties.
+    ClassValue {
+        /// The type name.
+        property_type: String,
+        /// A set of properties.
+        properties: Properties,
+    },
 }
 
 impl PropertyValue {
@@ -135,15 +143,31 @@ pub(crate) fn parse_properties(
     let mut p = HashMap::new();
     parse_tag!(parser, "properties", {
         "property" => |attrs:Vec<OwnedAttribute>| {
-            let (t, v_attr, k) = get_attrs!(
+            let (t, v_attr, k, p_t) = get_attrs!(
                 for attr in attrs {
                     Some("type") => obj_type = attr,
                     Some("value") => value = attr,
+                    Some("propertytype") => propertytype = attr,
                     "name" => name = attr
                 }
-                (obj_type, value, name)
+                (obj_type, value, name, propertytype)
             );
             let t = t.unwrap_or_else(|| "string".to_owned());
+            if t == "class" {
+                // Class properties will have their member values stored in a nested <properties>
+                // element. Only the actually set members are saved. When no members have been set
+                // the properties element is left out entirely.
+                let properties = if has_properties_tag_next(parser) {
+                    parse_properties(parser)?
+                } else {
+                    HashMap::new()
+                };
+                p.insert(k, PropertyValue::ClassValue {
+                    property_type: p_t.unwrap_or_else(|| "class".to_owned()),
+                    properties,
+                });
+                return Ok(());
+            }
 
             let v: String = match v_attr {
                 Some(val) => val,
@@ -163,4 +187,27 @@ pub(crate) fn parse_properties(
         },
     });
     Ok(p)
+}
+
+/// Checks if there is a properties tag next in the parser. Will consume any whitespace or comments.
+fn has_properties_tag_next(parser: &mut impl Iterator<Item = XmlEventResult>) -> bool {
+    let mut peekable = parser.by_ref().peekable();
+    while let Some(Ok(next)) = peekable.peek() {
+        match next {
+            XmlEvent::StartElement { name, .. } if name.local_name == "properties" => return true,
+            // Ignore whitespace and comments
+            XmlEvent::Whitespace(_) => {
+                peekable.next();
+            }
+            XmlEvent::Comment(_) => {
+                peekable.next();
+            }
+            // If we encounter anything else than whitespace, comments or the properties tag, we
+            // assume there are no properties.
+            _ => {
+                return false;
+            }
+        }
+    }
+    false
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -219,6 +219,7 @@ fn test_object_group_property() {
     };
     assert!(prop_value);
 }
+
 #[test]
 fn test_tileset_property() {
     let r = Loader::new()
@@ -325,6 +326,33 @@ fn test_object_property() {
 }
 
 #[test]
+fn test_class_property() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_class_property.tmx")
+        .unwrap();
+    let layer = r.get_layer(1).unwrap();
+    if let Some(PropertyValue::ClassValue {
+        property_type,
+        properties,
+    }) = layer
+        .as_object_layer()
+        .unwrap()
+        .get_object(0)
+        .unwrap()
+        .properties
+        .get("class property")
+    {
+        assert_eq!(property_type, "test_type");
+        assert_eq!(
+            properties.get("test_property_1").unwrap(),
+            &PropertyValue::IntValue(3)
+        );
+    } else {
+        panic!("Expected class property");
+    };
+}
+
+#[test]
 fn test_tint_color() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_image_layers.tmx")
@@ -335,7 +363,7 @@ fn test_tint_color() {
             alpha: 0x12,
             red: 0x34,
             green: 0x56,
-            blue: 0x78
+            blue: 0x78,
         })
     );
     assert_eq!(
@@ -344,7 +372,7 @@ fn test_tint_color() {
             alpha: 0xFF,
             red: 0x12,
             green: 0x34,
-            blue: 0x56
+            blue: 0x56,
         })
     );
 }
@@ -369,7 +397,7 @@ fn test_group_layers() {
             alpha: 0x12,
             red: 0x34,
             green: 0x56,
-            blue: 0x78
+            blue: 0x78,
         })),
         layer_group_1.properties.get("key")
     );
@@ -416,7 +444,7 @@ fn test_object_template_property() {
         object.shape,
         ObjectShape::Rect {
             width: 32.0,
-            height: 32.0
+            height: 32.0,
         }
     );
     assert_eq!(object.x, 32.0);


### PR DESCRIPTION
Adds support for the new class properties introduced in Tiled 1.8, as described [here](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#property).

I had to write some slightly hacky code to work around the fact that its child tag is optional, which would break the parser when it tried to parse it anyway.

The new property value ClassValue differs from the other PropertyValues in that its a struct enum variant, instead of a tuple one. I did this due to the additional property type that is included in it. Having it as a struct variant feels cleaner to me than having it as a two element tuple.