### PR TITLE
Support for class properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `text`, `width` and `height` members to `ObjectShape::Text`. (#278)
 - Implement `ResourceReader` for appropiate functions. (#272) **Read the README's FAQ for more information about this change.**
+- Support for custom type properties. (#283)
 
 ## Fixed
 - `ObjectShape::Text::kerning`'s default value, which should have been set to `true` instead of `false`. (#278)

--- a/assets/tiled_class_property.tmx
+++ b/assets/tiled_class_property.tmx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="4">
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="2" x="0" y="0" width="32" height="32">
+   <properties>
+    <property name="class property" type="class" propertytype="test_type">
+     <properties>
+      <property name="test_property_1" type="int" value="3"/>
+     </properties>
+    </property>
+    <property name="empty property" type="class" propertytype="empty_type"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -220,6 +220,7 @@ fn test_object_group_property() {
     };
     assert!(prop_value);
 }
+
 #[test]
 fn test_tileset_property() {
     let r = Loader::new()
@@ -326,6 +327,33 @@ fn test_object_property() {
 }
 
 #[test]
+fn test_class_property() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_class_property.tmx")
+        .unwrap();
+    let layer = r.get_layer(1).unwrap();
+    if let Some(PropertyValue::ClassValue {
+        property_type,
+        properties,
+    }) = layer
+        .as_object_layer()
+        .unwrap()
+        .get_object(0)
+        .unwrap()
+        .properties
+        .get("class property")
+    {
+        assert_eq!(property_type, "test_type");
+        assert_eq!(
+            properties.get("test_property_1").unwrap(),
+            &PropertyValue::IntValue(3)
+        );
+    } else {
+        panic!("Expected class property");
+    };
+}
+
+#[test]
 fn test_tint_color() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_image_layers.tmx")
@@ -336,7 +364,7 @@ fn test_tint_color() {
             alpha: 0x12,
             red: 0x34,
             green: 0x56,
-            blue: 0x78
+            blue: 0x78,
         })
     );
     assert_eq!(
@@ -345,7 +373,7 @@ fn test_tint_color() {
             alpha: 0xFF,
             red: 0x12,
             green: 0x34,
-            blue: 0x56
+            blue: 0x56,
         })
     );
 }
@@ -370,7 +398,7 @@ fn test_group_layers() {
             alpha: 0x12,
             red: 0x34,
             green: 0x56,
-            blue: 0x78
+            blue: 0x78,
         })),
         layer_group_1.properties.get("key")
     );
@@ -417,7 +445,7 @@ fn test_object_template_property() {
         object.shape,
         ObjectShape::Rect {
             width: 32.0,
-            height: 32.0
+            height: 32.0,
         }
     );
     assert_eq!(object.x, 32.0);


### PR DESCRIPTION
Adds support for the new class properties introduced in Tiled 1.8, as described [here](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#property).

I had to write some slightly hacky code to work around the fact that its child tag is optional, which would break the parser when it tried to parse it anyway.

The new property value ClassValue differs from the other PropertyValues in that its a struct enum variant, instead of a tuple one. I did this due to the additional property type that is included in it. Having it as a struct variant feels cleaner to me than having it as a two element tuple.

Recreated PR from [here](https://github.com/mapeditor/rs-tiled/pull/282), to change target branch