### PR TITLE
Use a BufReader as underlying reader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `ResourceReader` for appropiate functions. (#272) **Read the README's FAQ for more information about this change.**
 - Support for custom type properties. (#283)
 
+### Changed
+- Underlying reader for maps now uses a BufReader, which should give a large performance boost. (#286)
+
 ## Fixed
 - `ObjectShape::Text::kerning`'s default value, which should have been set to `true` instead of `false`. (#278)
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,3 +1,4 @@
+use std::io::BufReader;
 use std::{fs::File, io::Read, path::Path};
 
 /// A trait defining types that can load data from a [`ResourcePath`](crate::ResourcePath).
@@ -48,11 +49,12 @@ impl FilesystemResourceReader {
 }
 
 impl ResourceReader for FilesystemResourceReader {
-    type Resource = File;
+    type Resource = BufReader<File>;
     type Error = std::io::Error;
 
     fn read_from(&mut self, path: &Path) -> std::result::Result<Self::Resource, Self::Error> {
-        File::open(path)
+        let file = File::open(path)?;
+        Ok(BufReader::new(file))
     }
 }
 


### PR DESCRIPTION
This little change massively reduces the amount of syscalls done when reading files. Using the test files from #284, I saw a 400% performance boost.