### PR TITLE
Fix u32 parse panic in decode_csv

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     DecompressingError(std::io::Error),
     /// An error occured when decoding a base64 encoded dataset.
     Base64DecodingError(base64::DecodeError),
+    /// An error occurred when decoding a csv encoded dataset.
+    CsvDecodingError(String),
     /// An error occured when parsing a XML file, such as a TMX or TSX file.
     XmlDecodingError(xml::reader::Error),
     /// The XML stream ended before the document was fully parsed.
@@ -68,6 +70,7 @@ impl fmt::Display for Error {
             Error::MalformedAttributes(s) => write!(fmt, "{}", s),
             Error::DecompressingError(e) => write!(fmt, "{}", e),
             Error::Base64DecodingError(e) => write!(fmt, "{}", e),
+            Error::CsvDecodingError(e) => write!(fmt, "{}", e),
             Error::XmlDecodingError(e) => write!(fmt, "{}", e),
             Error::PrematureEnd(e) => write!(fmt, "{}", e),
             Error::PathIsNotFile => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,20 +1,39 @@
+use std::num::ParseIntError;
 use std::{fmt, path::PathBuf};
 
-/// Errors which occured when parsing the file
+/// Errors that can occur while decoding csv data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CsvDecodingError {
+    /// An error occurred when parsing tile data from a csv encoded dataset.
+    TileDataParseError(ParseIntError),
+}
+
+impl fmt::Display for CsvDecodingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CsvDecodingError::TileDataParseError(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for CsvDecodingError {}
+
+/// Errors which occurred when parsing the file
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// A attribute was missing, had the wrong type of wasn't formated
     /// correctly.
     MalformedAttributes(String),
-    /// An error occured when decompressing using the
+    /// An error occurred when decompressing using the
     /// [flate2](https://github.com/alexcrichton/flate2-rs) crate.
     DecompressingError(std::io::Error),
-    /// An error occured when decoding a base64 encoded dataset.
+    /// An error occurred when decoding a base64 encoded dataset.
     Base64DecodingError(base64::DecodeError),
     /// An error occurred when decoding a csv encoded dataset.
-    CsvDecodingError(String),
-    /// An error occured when parsing a XML file, such as a TMX or TSX file.
+    CsvDecodingError(CsvDecodingError),
+    /// An error occurred when parsing an XML file, such as a TMX or TSX file.
     XmlDecodingError(xml::reader::Error),
     /// The XML stream ended before the document was fully parsed.
     PrematureEnd(String),
@@ -25,7 +44,7 @@ pub enum Error {
     ResourceLoadingError {
         /// The path to the file that was unable to be opened.
         path: PathBuf,
-        /// The error that occured when trying to open the file.
+        /// The error that occurred when trying to open the file.
         err: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
     /// There was an invalid tile in the map parsed.
@@ -41,7 +60,7 @@ pub enum Error {
     ///
     /// [`PropertyValue`]: crate::PropertyValue
     InvalidPropertyValue {
-        /// A description of the error that occured.
+        /// A description of the error that occurred.
         description: String,
     },
     /// Found an unknown property value type while parsing a [`PropertyValue`].

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -42,7 +42,7 @@ fn parse_base64(parser: &mut impl Iterator<Item = XmlEventResult>) -> Result<Vec
                     base64::engine::general_purpose::PAD,
                 )
                 .decode(s.trim().as_bytes())
-                .map_err(Error::Base64DecodingError)
+                .map_err(Error::Base64DecodingError);
             }
             XmlEvent::EndElement { name, .. } if name.local_name == "data" => {
                 return Ok(Vec::new());
@@ -70,11 +70,13 @@ fn decode_csv(
     for next in parser {
         match next.map_err(Error::XmlDecodingError)? {
             XmlEvent::Characters(s) => {
-                let tiles = s
-                    .split(',')
-                    .map(|v| v.trim().parse().unwrap())
-                    .map(|bits| LayerTileData::from_bits(bits, tilesets))
-                    .collect();
+                let mut tiles = Vec::new();
+                for v in s.split(',') {
+                    match v.trim().parse() {
+                        Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
+                        Err(e) => return Err(Error::CsvDecodingError(e.to_string())),
+                    }
+                }
                 return Ok(tiles);
             }
             XmlEvent::EndElement { name, .. } if name.local_name == "data" => {

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, io::Read};
 use base64::Engine;
 use xml::reader::XmlEvent;
 
-use crate::{util::XmlEventResult, Error, LayerTileData, MapTilesetGid, Result};
+use crate::{util::XmlEventResult, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
 
 pub(crate) fn parse_data_line(
     encoding: Option<String>,
@@ -74,7 +74,11 @@ fn decode_csv(
                 for v in s.split(',') {
                     match v.trim().parse() {
                         Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
-                        Err(e) => return Err(Error::CsvDecodingError(e.to_string())),
+                        Err(e) => {
+                            return Err(Error::CsvDecodingError(
+                                CsvDecodingError::TileDataParseError(e),
+                            ))
+                        }
                     }
                 }
                 return Ok(tiles);

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Read, path::Path};
+use std::path::Path;
 
 use crate::{
     DefaultResourceCache, FilesystemResourceReader, Map, ResourceCache, ResourceReader, Result,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
+
 use tiled::{
-    Color, FiniteTileLayer, GroupLayer, HorizontalAlignment, Layer, LayerType, Loader, Map,
-    ObjectLayer, ObjectShape, PropertyValue, ResourceCache, TileLayer, TilesetLocation,
-    VerticalAlignment, WangId,
+    Color, FiniteTileLayer, HorizontalAlignment, LayerType, Loader, Map, ObjectShape,
+    PropertyValue, ResourceCache, TileLayer, TilesetLocation, VerticalAlignment, WangId,
 };
 
 fn as_finite<'map>(data: TileLayer<'map>) -> FiniteTileLayer<'map> {


### PR DESCRIPTION
This PR fixes an unhandled parsing error in `decode_csv` found with `cargo fuzz`. The following input no longer causes a panic:

```
<?xml version="1.0" encoding="UTF-8"?>
<map version="1.4" tiledversion="1.4.0" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="32" tileheight="32" infinite="0" backgroundcolor="#ff00ff" nextlayerid="3" nextobjectid="5">
 <tileset firstgid="1" name="tilesheet" tilewidth="32" tileheight="32" tilecount="84" columns="14">
  <properties>
   <property name="tileset property" value="tsp"/>
  </properties>
  <image source="tilesheet.png" width="448" height="192"/>
  <tile id="1">
   <properties>
    <property name="a tile property" value="123"/>
   </properties>
  </tile>
 </tileset>
 <layer id="1" name="Tile Layer 1" width="100" height="100">
  <properties>
   <property name="prop1" value="12"/>
   <property name="prop2" value="some text"/>
   <property name="prop3">Line 1
Line 2
Line 3,
  etc
   </property>
  </properties>
  <data encoding="csv">
35,35,35,35,35,33,33,33,33,33,33,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,,0,
0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 </objectgroup>
</map>
```