### PR TITLE
Fix index out of bounds in InfiniteTileLayerData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ObjectShape::Text::kerning`'s default value, which should have been set to `true` instead of `false`. (#278)
 - Unhandled u32 parsing panic in `decode_csv`. (#288)
 - Panic in `<Color as FromStr>::from_str` when parsing non-ascii input. (#290)
+- Index out of bounds in `InfiniteTileLayerData` when parsing a chunk. (#289)
 
 ## [Unreleased]
 ## Changed

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -47,6 +47,10 @@ impl InfiniteTileLayerData {
                         let internal_pos = (x - chunk.x, y - chunk.y);
                         let internal_index = (internal_pos.0 + internal_pos.1 * chunk.width as i32) as usize;
 
+                        if internal_index >= chunk.tiles.len() {
+                            return Err(Error::InvalidTileFound);
+                        }
+
                         chunks.entry(chunk_pos).or_insert_with(ChunkData::new).tiles[chunk_index] = chunk.tiles[internal_index];
                     }
                 }


### PR DESCRIPTION
Another one found with cargo fuzz.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<map version="1.2" tiledversion="2020.05.20" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="32" tileheight="32" infinite="1" backgroundcolor="#ff00ff" nextlayerid="6" nextobjectid="5">
 <editorsettings>
  <chunksize width="32" height="32"/>
 </editorsettings>
 <tileset firstgid="1" name="tilesheet" tilewidth="32" tileheight="32" tilecount="84" columns="14">
  <image source="tilesheet.png" width="448" height="192"/>
  <tile id="1">
   <properties>
    <property name="a tile property" value="123"/>
   </properties>
  </tile>
 </tileset>
 <tileset firstgid="85" source="tilesheet.tsx"/>
 <layer id="0" name="Background" width="100" height="100">
  <data encoding="base64" compression="zlib">
   <chunk x="-32" y="0" width="32" height="32">
   eJztzTENAAAMw7BiGH+wg9CjryPldrJ142t8Pp/P5/P5fD6fz+fz+w/olSQB
  </chunk>
   <chunk x="0" y="0" width="32" height="32">
   eJztwwEJAAAMBKHL8P3DrsdQcNVUVVXV1w/BwEgB
  </chunk>
   <chunk x="-32" y="32" width="32" height="32">
   eJztzcEJAAAIA7HO4P7DOkRBEBK49yWdKWv5+/v7+/v73/8BgH8WAIoSAQ==
  </chunk>
   <chunk x="0" y="32" width="32" height="32">
   eJztwwEJAAAAAqA29H9sQ1KwSaqqXgUA/gxxUCQB
  </chunk>
  </data>
 </layer>
 <layer id="4" name="Ground" width="100" height="100" locked="1">
  <data encoding="base64" compression="zlib">
   <chunk x="0" y="0" width="32" height="32">
   eJztVLsOwjAQi4Af6MAnIBb4AgRiRUKw8+hMS2fg87mInGSdLk0ThgyNJYtXajvxBWMKCgoK4nAhXom3TN4dsSE+XY5/s/B+NErdB/FOfANryJKSw2o2HrYiZ+e+q4AvkSM2Az/PXMD7j5KzFc9jjlr5PYRKcCI+h/xRx66JPQN7rivi2r0ujd4/+/fpp5yB1Z0Dff3jnODsS3aBjJq/1ZRzLfvnvflmtW92Q/4zRzkL2D/efS0r34EU/yHr8fzlHWTKNUP0D6a/U+6V9/5RldL9pyau10pVSvPn/58NUOtWm0mfVmgdgrvbmd/92xu9W20mfVqhdRrQPwfG7n8knomnTP4W24zexX9c/l+dHlQo
  </chunk>
   <chunk x="0" y="32" width="32" height="32">
   eJ"376">
   <polyline points="0,0 -111,-63 -203,27 -205,-130 -78,-150 -6,-6"/>
  </object>
  <object id="4" x="479" y="84">
   <polygon pointsE"0,0 139,128 -55,64 -37,-49 159,47 138,126"/>
  </object>
 </objectgroup>
</map>
```

```
fuzz/target/x86_64-unknown-linux-gnu/release/tiled: Running 1 inputs 1 time(s) each.
Running: fuzz/artifacts/tiled/minimized-from-12291cfb0f7397e138433f0cc81f90c878968d5a
thread '<unnamed>' panicked at /mnt/e/code/rs-tiled/src/layers/tile/infinite.rs:50:112:
index out of bounds: the len is 1023 but the index is 1023
stack backtrace:
   0: rust_begin_unwind
             at /rustc/36153f1a4e3162f0a143c7b3e468ecb3beb0008e/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/36153f1a4e3162f0a143c7b3e468ecb3beb0008e/library/core/src/panicking.rs:72:14
   2: core::panicking::panic_bounds_check
             at /rustc/36153f1a4e3162f0a143c7b3e468ecb3beb0008e/library/core/src/panicking.rs:274:5
   3: tiled::layers::tile::infinite::InfiniteTileLayerData::new::{{closure}}
             at ./src/layers/tile/infinite.rs:50
   4: tiled::layers::tile::infinite::InfiniteTileLayerData::new
             at ./src/util.rs:189:60
   5: tiled::layers::tile::TileLayerData::new::{{closure}}
             at ./src/layers/tile/mod.rs:115:45
   6: tiled::layers::tile::TileLayerData::new
             at ./src/util.rs:189:60
   7: tiled::layers::LayerData::new
             at ./src/layers/mod.rs:112:40
   8: tiled::map::Map::parse_xml::{{closure}}
             at ./src/map.rs:190:29
   9: tiled::map::Map::parse_xml
             at ./src/util.rs:189:60
  10: tiled::parse::xml::map::parse_map
             at ./src/parse/xml/map.rs:27:28
  11: tiled::loader::Loader<Cache,Reader>::load_tmx_map
             at ./src/loader.rs:169:9
  12: tiled::_::__libfuzzer_sys_run
             at ./fuzz/fuzz_targets/tiled.rs:31:13
  13: rust_fuzzer_test_input
             at /home/smacks/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/src/lib.rs:224:17
  14: libfuzzer_sys::test_input_wrap::{{closure}}
             at /home/smacks/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/src/lib.rs:61:9
  15: std::panicking::try::do_call
             at /rustc/36153f1a4e3162f0a143c7b3e468ecb3beb0008e/library/std/src/panicking.rs:559:40
  16: __rust_try
  17: std::panicking::try
             at /rustc/36153f1a4e3162f0a143c7b3e468ecb3beb0008e/library/std/src/panicking.rs:523:19
  18: std::panic::catch_unwind
             at /rustc/36153f1a4e3162f0a143c7b3e468ecb3beb0008e/library/std/src/panic.rs:149:14
  19: LLVMFuzzerTestOneInput
             at /home/smacks/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/src/lib.rs:59:22
  20: _ZN6fuzzer6Fuzzer15ExecuteCallbackEPKhm
             at /home/smacks/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/libfuzzer/FuzzerLoop.cpp:612:15
  21: _ZN6fuzzer10RunOneTestEPNS_6FuzzerEPKcm
             at /home/smacks/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/libfuzzer/FuzzerDriver.cpp:324:21
  22: _ZN6fuzzer12FuzzerDriverEPiPPPcPFiPKhmE
             at /home/smacks/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/libfuzzer/FuzzerDriver.cpp:860:19
  23: main
             at /home/smacks/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/libfuzzer/FuzzerMain.cpp:20:30
  24: <unknown>
  25: __libc_start_main
  26: _start
```
