### PR TITLE
Add source members to `Tileset`, `Map` and `Template`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased (0.13.0)]
 ### Added
-- A way to obtain where tilesets, templates and maps have been loaded from
+- Added a `source` member to `Tileset`, `Map` and `Template`, which stores the resource path they have been loaded from.
 
 ## [0.12.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased (0.13.0)]
+### Added
+- A way to obtain where tilesets, templates and maps have been loaded from
+
 ## [0.12.0]
 ### Added
 - Add `text`, `width` and `height` members to `ObjectShape::Text`. (#278)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ use tiled::Loader;
 
 fn main() {
     let mut loader = Loader::new();
-    let map = loader.load_tmx_map("assets/tiled_base64_zlib.tmx").unwrap();
+    let map = loader.load_tmx_map("assets/tiled_base64_external.tmx").unwrap();
     println!("{:?}", map);
     println!("{:?}", map.tilesets()[0].get_tile(0).unwrap().probability);
     

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,6 +1,12 @@
 //! Structures related to Tiled maps.
 
-use std::{collections::HashMap, fmt, path::Path, str::FromStr, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
 
 use xml::attribute::OwnedAttribute;
 
@@ -22,6 +28,8 @@ pub(crate) struct MapTilesetGid {
 #[derive(PartialEq, Clone, Debug)]
 pub struct Map {
     version: String,
+    /// The path first used in a [`ResourceReader`] to load this map.
+    pub source: PathBuf,
     /// The way tiles are laid out in the map.
     pub orientation: Orientation,
     /// Width of the map, in tiles.
@@ -253,6 +261,7 @@ impl Map {
 
         Ok(Map {
             version: v,
+            source: map_path.to_owned(),
             orientation: o,
             width: w,
             height: h,

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use xml::EventReader;
@@ -15,6 +15,8 @@ use crate::{
 /// maps.
 #[derive(Clone, Debug)]
 pub struct Template {
+    /// The path first used in a [`ResourceReader`] to load this template.
+    pub source: PathBuf,
     /// The tileset this template contains a reference to
     pub tileset: Option<Arc<Tileset>>,
     /// The object data for this template
@@ -102,6 +104,10 @@ impl Template {
 
         let object = object.ok_or(Error::TemplateHasNoObject)?;
 
-        Ok(Arc::new(Template { tileset, object }))
+        Ok(Arc::new(Template {
+            source: template_path.to_owned(),
+            tileset,
+            object,
+        }))
     }
 }

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -17,6 +17,10 @@ pub use wangset::*;
 /// Also see the [TMX docs](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tileset).
 #[derive(Debug, PartialEq, Clone)]
 pub struct Tileset {
+    /// The path first used in a [`ResourceReader`] to load this tileset.
+    ///
+    /// For embedded tilesets, this path will be the same as the template or map's source.
+    pub source: PathBuf,
     /// The name of the tileset, set by the user.
     pub name: String,
     /// The (maximum) width in pixels of the tiles in this tileset. Irrelevant for [image collection]
@@ -157,6 +161,7 @@ impl Tileset {
 
         Self::finish_parsing_xml(
             parser,
+            path.to_owned(),
             TilesetProperties {
                 spacing,
                 margin,
@@ -227,6 +232,7 @@ impl Tileset {
 
         Self::finish_parsing_xml(
             parser,
+            path.to_owned(),
             TilesetProperties {
                 spacing,
                 margin,
@@ -245,6 +251,7 @@ impl Tileset {
 
     fn finish_parsing_xml(
         parser: &mut impl Iterator<Item = XmlEventResult>,
+        container_path: PathBuf,
         prop: TilesetProperties,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -303,6 +310,7 @@ impl Tileset {
             .unwrap_or_else(|| Self::calculate_columns(&image, prop.tile_width, margin, spacing))?;
 
         Ok(Tileset {
+            source: container_path,
             name: prop.name,
             user_type: prop.user_type,
             tile_width: prop.tile_width,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,7 +12,7 @@ fn as_finite<'map>(data: TileLayer<'map>) -> FiniteTileLayer<'map> {
     }
 }
 
-fn compare_everything_but_tileset_sources(r: &Map, e: &Map) {
+fn compare_everything_but_sources(r: &Map, e: &Map) {
     assert_eq!(r.version(), e.version());
     assert_eq!(r.orientation, e.orientation);
     assert_eq!(r.width, e.width);
@@ -39,10 +39,10 @@ fn test_gzip_and_zlib_encoded_and_raw_are_the_same() {
         .load_tmx_map("assets/tiled_base64_zstandard.tmx")
         .unwrap();
     let c = Loader::new().load_tmx_map("assets/tiled_csv.tmx").unwrap();
-    compare_everything_but_tileset_sources(&z, &g);
-    compare_everything_but_tileset_sources(&z, &r);
-    compare_everything_but_tileset_sources(&z, &c);
-    compare_everything_but_tileset_sources(&z, &zstd);
+    compare_everything_but_sources(&z, &g);
+    compare_everything_but_sources(&z, &r);
+    compare_everything_but_sources(&z, &c);
+    compare_everything_but_sources(&z, &zstd);
 
     let layer = as_finite(c.get_layer(0).unwrap().as_tile_layer().unwrap());
     {
@@ -65,11 +65,11 @@ fn test_external_tileset() {
     let e = loader
         .load_tmx_map("assets/tiled_base64_external.tmx")
         .unwrap();
-    compare_everything_but_tileset_sources(&r, &e);
+    compare_everything_but_sources(&r, &e);
 }
 
 #[test]
-fn test_sources() {
+fn test_cache() {
     let mut loader = Loader::new();
     let e = loader
         .load_tmx_map("assets/tiled_base64_external.tmx")
@@ -81,6 +81,36 @@ fn test_sources() {
     assert_eq!(
         e.tilesets()[0].image.as_ref().unwrap().source,
         PathBuf::from("assets/tilesheet.png")
+    );
+}
+
+#[test]
+fn test_external_sources() {
+    let mut loader = Loader::new();
+    let e = loader
+        .load_tmx_map("assets/tiled_base64_external.tmx")
+        .unwrap();
+    assert_eq!(e.source, "assets/tiled_base64_external.tmx".to_owned());
+    assert_eq!(e.tilesets()[0].source, "assets/tilesheet.tsx".to_owned());
+
+    let e = loader
+        .load_tmx_map("assets/tiled_object_template.tmx")
+        .unwrap();
+    assert_eq!(e.source, "assets/tiled_object_template.tmx".to_owned());
+    assert_eq!(
+        e.tilesets()[0].source,
+        "assets/tiled_object_template.tx".to_owned()
+    );
+}
+
+#[test]
+fn test_embedded_sources() {
+    let e = loader.load_tmx_map("assets/tiled_base64_gzip.tmx").unwrap();
+
+    assert_eq!(e.source, "assets/tiled_base64_gzip.tmx".to_owned());
+    assert_eq!(
+        e.tilesets()[0].source,
+        "assets/tiled_base64_gzip.tmx".to_owned()
     );
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -101,7 +101,7 @@ fn test_external_sources() {
         .unwrap();
     assert_eq!(e.source, PathBuf::from("assets/tiled_object_template.tmx"));
     assert_eq!(
-        e.tilesets()[0].source,
+        loader.cache().templates.values().next().unwrap().source,
         PathBuf::from("assets/tiled_object_template.tx")
     );
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -105,6 +105,7 @@ fn test_external_sources() {
 
 #[test]
 fn test_embedded_sources() {
+    let mut loader = Loader::new();
     let e = loader.load_tmx_map("assets/tiled_base64_gzip.tmx").unwrap();
 
     assert_eq!(e.source, "assets/tiled_base64_gzip.tmx".to_owned());

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -90,16 +90,19 @@ fn test_external_sources() {
     let e = loader
         .load_tmx_map("assets/tiled_base64_external.tmx")
         .unwrap();
-    assert_eq!(e.source, "assets/tiled_base64_external.tmx".to_owned());
-    assert_eq!(e.tilesets()[0].source, "assets/tilesheet.tsx".to_owned());
+    assert_eq!(e.source, PathBuf::from("assets/tiled_base64_external.tmx"));
+    assert_eq!(
+        e.tilesets()[0].source,
+        PathBuf::from("assets/tilesheet.tsx")
+    );
 
     let e = loader
         .load_tmx_map("assets/tiled_object_template.tmx")
         .unwrap();
-    assert_eq!(e.source, "assets/tiled_object_template.tmx".to_owned());
+    assert_eq!(e.source, PathBuf::from("assets/tiled_object_template.tmx"));
     assert_eq!(
         e.tilesets()[0].source,
-        "assets/tiled_object_template.tx".to_owned()
+        PathBuf::from("assets/tiled_object_template.tx")
     );
 }
 
@@ -108,10 +111,10 @@ fn test_embedded_sources() {
     let mut loader = Loader::new();
     let e = loader.load_tmx_map("assets/tiled_base64_gzip.tmx").unwrap();
 
-    assert_eq!(e.source, "assets/tiled_base64_gzip.tmx".to_owned());
+    assert_eq!(e.source, PathBuf::from("assets/tiled_base64_gzip.tmx"));
     assert_eq!(
         e.tilesets()[0].source,
-        "assets/tiled_base64_gzip.tmx".to_owned()
+        PathBuf::from("assets/tiled_base64_gzip.tmx")
     );
 }
 


### PR DESCRIPTION
Closes #263. Adds a `source` member so users can obtain where stuff has been loaded from.