### PR TITLE
Extend lifetime of layers from GroupLayer::get_layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Improved documentation on `Map::layers` and `Map::get_layer`. (#306)
-- Extend lifetime of `Layer`s returned from `GroupLayer::get_layer` to the map's.
+- Extend lifetime of `Layer`s returned from `GroupLayer::get_layer` to the map's. (#307)
 
 ## [0.12.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Improved documentation on `Map::layers` and `Map::get_layer`. (#306)
+- Extend lifetime of `Layer`s returned from `GroupLayer::get_layer` to the map's.
 
 ## [0.12.0]
 ### Added

--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -129,7 +129,7 @@ impl<'map> GroupLayer<'map> {
             .map(move |layer| Layer::new(map, layer))
     }
     /// Gets a specific layer from the group by index.
-    pub fn get_layer(&self, index: usize) -> Option<Layer> {
+    pub fn get_layer(&self, index: usize) -> Option<Layer<'map>> {
         self.data
             .layers
             .get(index)


### PR DESCRIPTION
From #306. Not the first time that `Layer`s are given with shorter lifetimes than intended.