### PR TITLE
Prepare for 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.1]
 ### Changed
 - Improved documentation on `Map::layers` and `Map::get_layer`. (#306)
 - Extend lifetime of `Layer`s returned from `GroupLayer::get_layer` to the map's. (#307)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiled"
-version = "0.12.0"
+version = "0.12.1"
 description = "A rust crate for loading maps created by the Tiled editor"
 categories = ["game-development"]
 keywords = ["gamedev", "tiled", "tmx", "map"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rs-tiled
 ```toml
-tiled = "0.12.0"
+tiled = "0.12.1"
 ```
 
 [![Rust](https://github.com/mapeditor/rs-tiled/actions/workflows/rust.yml/badge.svg)](https://github.com/mapeditor/rs-tiled/actions/workflows/rust.yml)


### PR DESCRIPTION
Prepare for a new crates.io release.

Version will be released shortly after merging this PR.