### PR TITLE
Fixed template instance size and position overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased (0.12.2)]
+### Fixed
+- Fixed template instance size and position overrides in `ObjectData::shape`. (#309)
+
 ## [0.12.1]
 ### Changed
 - Improved documentation on `Map::layers` and `Map::get_layer`. (#306)

--- a/assets/tiled_object_template.tmx
+++ b/assets/tiled_object_template.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" width="3" height="3" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="3">
+<map version="1.11" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="3" height="3" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="4">
  <tileset firstgid="1" source="tilesheet.tsx"/>
  <layer id="1" name="Tile Layer 1" width="3" height="3">
   <data encoding="csv">
@@ -14,5 +14,6 @@
    </properties>
   </object>
   <object id="2" gid="45" x="0" y="32" width="32" height="32"/>
+  <object id="3" template="tiled_object_template.tx" x="0" y="64" width="64" height="32"/>
  </objectgroup>
 </map>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -439,6 +439,7 @@ fn test_object_template_property() {
     let object_layer = r.get_layer(1).unwrap().as_object_layer().unwrap();
     let object = object_layer.get_object(0).unwrap(); // The templated object
     let object_nt = object_layer.get_object(1).unwrap(); // The non-templated object
+    let object_resized = object_layer.get_object(2).unwrap(); // The resized templated object
 
     // Test core properties
     assert_eq!(
@@ -450,6 +451,13 @@ fn test_object_template_property() {
     );
     assert_eq!(object.x, 32.0);
     assert_eq!(object.y, 32.0);
+    assert_eq!(
+        object_resized.shape,
+        ObjectShape::Rect {
+            width: 64.0,
+            height: 32.0,
+        }
+    );
 
     // Test properties are copied over
     assert_eq!(


### PR DESCRIPTION
Template instances of rectangle, ellipse and text objects can override the width and height of the template object. This is now taken into account when reading out the attributes and when inheriting the shape from the template.

Template instances of point objects are now also correctly storing the instance position in the Point shape, instead of the position of the template object.

Closes #310