### PR TITLE
Prepare for 0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased (0.13.0)]
+## [0.13.0]
 ### Added
-- Added a `source` member to `Tileset`, `Map` and `Template`, which stores the resource path they have been loaded from.
+- Added a `source` member to `Tileset`, `Map` and `Template`, which stores the resource path they have been loaded from. (#303)
 - Add `hex_side_length` member to `Map`. (#313)
 
-## [Unreleased (0.12.2)]
 ### Fixed
 - Fixed template instance size and position overrides in `ObjectData::shape`. (#309)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiled"
-version = "0.12.1"
+version = "0.13.0"
 description = "A rust crate for loading maps created by the Tiled editor"
 categories = ["game-development"]
 keywords = ["gamedev", "tiled", "tmx", "map"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rs-tiled
 ```toml
-tiled = "0.12.1"
+tiled = "0.13.0"
 ```
 
 [![Rust](https://github.com/mapeditor/rs-tiled/actions/workflows/rust.yml/badge.svg)](https://github.com/mapeditor/rs-tiled/actions/workflows/rust.yml)


### PR DESCRIPTION
Preparing for new major release. I'll skip 0.12.2 since the `source` additions are pretty useful to have.