### PR TITLE
Corrected the type of Map.hex_side_length

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -57,7 +57,7 @@ pub struct Map {
     /// will be the same as the one from the tilesets the map is using.
     pub tile_height: u32,
     /// The length of the side of a hexagonal tile in pixels (used by tile layers on hexagonal maps).
-    pub hex_side_length: Option<u32>,
+    pub hex_side_length: Option<i32>,
     /// The stagger axis of Hexagonal/Staggered map.
     pub stagger_axis: StaggerAxis,
     /// The stagger index of Hexagonal/Staggered map.


### PR DESCRIPTION
Because Tiled doesn't restrict this value to the unsigned range, rs-tiled probably shouldn't either.