### PR TITLE
Parse repeatx/repeaty from Image layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- New `ImageLayer` `repeat_x`/`y` fields are now parsed from map image layers.
+
 ## [0.14.0]
 ### Added
 - Added a new crate feature `world` to enable support for parsing `World` files.

--- a/assets/tiled_repeat.tmx
+++ b/assets/tiled_repeat.tmx
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.5" tiledversion="1.7.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="4" nextobjectid="1">
+ <tileset firstgid="1" source="tilesheet.tsx"/>
+ <layer id="3" name="Background" width="10" height="10">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+48,49,50,48,49,50,48,49,50,0,
+62,63,64,62,63,64,62,63,64,0,
+76,77,78,76,77,78,76,77,78,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+ <layer id="2" name="Middle" width="10" height="10">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,6,7,8,0,0,0,0,0,
+0,0,20,21,22,0,6,7,8,0,
+0,0,34,35,36,0,20,21,22,0,
+0,0,0,0,0,0,34,35,36,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+ <layer id="1" name="Foreground" width="10" height="10">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,3,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+ <imagelayer id="4" name="ImageLayer" repeatx="1" repeaty="1">
+  <image source="tilesheet.png" width="320" height="320"/>
+ </imagelayer>
+</map>

--- a/src/layers/image.rs
+++ b/src/layers/image.rs
@@ -1,8 +1,10 @@
 use std::{collections::HashMap, path::Path};
 
+use xml::attribute::OwnedAttribute;
+
 use crate::{
     parse_properties,
-    util::{map_wrapper, parse_tag, XmlEventResult},
+    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
     Error, Image, Properties, Result,
 };
 
@@ -11,17 +13,31 @@ use crate::{
 pub struct ImageLayerData {
     /// The single image this layer contains, if it exists.
     pub image: Option<Image>,
+    /// The layer's x repeat factor (true = repeat, false = no repeat).
+    pub repeat_x: bool,
+    /// The layer's y repeat factor (true = repeat, false = no repeat).
+    pub repeat_y: bool,
 }
 
 impl ImageLayerData {
     pub(crate) fn new(
         parser: &mut impl Iterator<Item = XmlEventResult>,
+        attrs: Vec<OwnedAttribute>,
         map_path: &Path,
     ) -> Result<(Self, Properties)> {
         let mut image: Option<Image> = None;
         let mut properties = HashMap::new();
 
         let path_relative_to = map_path.parent().ok_or(Error::PathIsNotFile)?;
+
+        // Parse repeat attributes from the imagelayer tag
+        let (repeat_x, repeat_y) = get_attrs!(
+            for v in attrs {
+                Some("repeatx") => repeat_x ?= v.parse::<i32>().map(|val| val == 1),
+                Some("repeaty") => repeat_y ?= v.parse::<i32>().map(|val| val == 1),
+            }
+            (repeat_x, repeat_y)
+        );
 
         parse_tag!(parser, "imagelayer", {
             "image" => |attrs| {
@@ -33,7 +49,14 @@ impl ImageLayerData {
                 Ok(())
             },
         });
-        Ok((ImageLayerData { image }, properties))
+        Ok((
+            ImageLayerData {
+                image,
+                repeat_x: repeat_x.unwrap_or(false),
+                repeat_y: repeat_y.unwrap_or(false),
+            },
+            properties,
+        ))
     }
 }
 

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -125,7 +125,7 @@ impl LayerData {
                 (LayerDataType::Objects(ty), properties)
             }
             LayerTag::Image => {
-                let (ty, properties) = ImageLayerData::new(parser, map_path)?;
+                let (ty, properties) = ImageLayerData::new(parser, attrs, map_path)?;
                 (LayerDataType::Image(ty), properties)
             }
             LayerTag::Group => {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -397,6 +397,36 @@ fn test_parallax_layers() {
 }
 
 #[test]
+fn test_repeat() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_repeat.tmx")
+        .unwrap();
+    for (i, layer) in r.layers().enumerate() {
+        match i {
+            0 => {
+                assert_eq!(layer.name, "Background");
+                // Tile layers don't have repeat properties
+            }
+            1 => {
+                assert_eq!(layer.name, "Middle");
+                // Tile layers don't have repeat properties
+            }
+            2 => {
+                assert_eq!(layer.name, "Foreground");
+                // Tile layers don't have repeat properties
+            }
+            3 => {
+                assert_eq!(layer.name, "ImageLayer");
+                let image_layer = layer.as_image_layer().unwrap();
+                assert_eq!(image_layer.repeat_x, true);
+                assert_eq!(image_layer.repeat_y, true);
+            }
+            _ => panic!("unexpected layer"),
+        }
+    }
+}
+
+#[test]
 fn test_object_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_object_property.tmx")


### PR DESCRIPTION
This allows map renderers to respect the image layer repeatx/repeaty properties.

relates to https://github.com/adrien-bon/bevy_ecs_tiled/issues/123