### PR TITLE
updated edition to 2024, fixed clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ base64 = "0.22.1"
 xml-rs = "0.8.4"
 zstd = { version = "0.13.1", optional = true, default-features = false }
 flate2 = "1.0.28"
-serde = { version = "1.0.216", optional = true }
+serde = { version = "1.0.216", features = ["derive"], optional = true }
 serde_json = { version = "1.0.133", optional = true }
 serde_regex = { version = "1.1.0", optional = true }
 regex = { version = "1.11.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,13 @@ repository = "https://github.com/mapeditor/rs-tiled"
 readme = "README.md"
 license = "MIT"
 authors = ["Matthew Hall <matthew@quickbeam.me.uk>"]
-edition = "2018"
+edition = "2024"
 include = ["src/**/*.rs", "README.md", "LICENSE", "CHANGELOG.md"]
+
+[lints]
+rust.rust_2018_idioms = "deny"
+clippy.too_many_arguments = "allow"
+
 
 [features]
 default = ["zstd"]

--- a/README.md
+++ b/README.md
@@ -22,16 +22,13 @@ The minimum supported TMX version is 0.13.
 ```rust
 use tiled::Loader;
 
-fn main() {
-    let mut loader = Loader::new();
-    let map = loader.load_tmx_map("assets/tiled_base64_external.tmx").unwrap();
-    println!("{:?}", map);
-    println!("{:?}", map.tilesets()[0].get_tile(0).unwrap().probability);
-    
-    let tileset = loader.load_tsx_tileset("assets/tilesheet.tsx").unwrap();
-    assert_eq!(*map.tilesets()[0], tileset);
-}
+let mut loader = Loader::new();
+let map = loader.load_tmx_map("assets/tiled_base64_external.tmx").unwrap();
+println!("{:?}", map);
+println!("{:?}", map.tilesets()[0].get_tile(0).unwrap().probability);
 
+let tileset = loader.load_tsx_tileset("assets/tilesheet.tsx").unwrap();
+assert_eq!(*map.tilesets()[0], tileset);
 ```
 
 ## FAQ
@@ -71,9 +68,8 @@ The crate supports WASM, but since it does not currently support asynchronous lo
 tiled = { version = ".....", features = ["wasm"] }
 ```
 
-- Second, since you cannot use the filesystem as normally on the web, you cannot use `FilesystemResourceReader`. As such,
-you'll need to implement your own `ResourceReader`. This is a pretty simple task, as you just need to return anything
-that is `Read`able when given a path, e.g.:
+- Second, since you cannot use the filesystem as normally on the web, you cannot use `FilesystemResourceReader`. As such, you'll need to implement your own `ResourceReader`. This is a pretty simple task, as you just need to return anything that is `Read`able when given a path, e.g.:
+
 ```rust,ignore
 use std::io::Cursor;
 

--- a/examples/ggez/main.rs
+++ b/examples/ggez/main.rs
@@ -7,10 +7,11 @@ mod map;
 mod res_reader;
 
 use ggez::{
+    Context, GameResult,
     event::{self, MouseButton},
     graphics::{self, DrawParam},
     mint::Point2,
-    Context, GameResult, *,
+    *,
 };
 use map::MapHandler;
 use res_reader::GgezResourceReader;

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, f32::consts::FRAC_PI_2};
 
 use ggez::{
     graphics::{self, Canvas, DrawParam, InstanceArray},
@@ -173,17 +173,41 @@ impl MapHandler {
                                             * 20.0;
                                     }
 
-                                    batch.push(
-                                        DrawParam::default()
-                                            .src(get_tile_rect(ts, tile.id(), ts_size.0, ts_size.1))
-                                            .dest([dx, dy])
-                                            .color(ggez::graphics::Color::from_rgba(
-                                                0xFF,
-                                                0xFF,
-                                                0xFF,
-                                                (layer.opacity * 255.0) as u8,
-                                            )),
-                                    );
+                                    // Handle tile rotation and mirroring
+                                    let offset_x = self.tile_width() as f32 / 2.0;
+                                    let offset_y = self.tile_height() as f32 / 2.0;
+
+                                    let mut draw_param = DrawParam::default()
+                                        .src(get_tile_rect(ts, tile.id(), ts_size.0, ts_size.1))
+                                        .offset([offset_x, offset_y])
+                                        .dest([dx + offset_x, dy + offset_y])
+                                        .color(ggez::graphics::Color::from_rgba(
+                                            0xFF,
+                                            0xFF,
+                                            0xFF,
+                                            (layer.opacity * 255.0) as u8,
+                                        ));
+
+                                    let (fd, fh, fv) = (tile.flip_d, tile.flip_h, tile.flip_v);
+
+                                    draw_param = if fd {
+                                        match (fh, fv) {
+                                            (true, true) => {
+                                                draw_param.scale([-1.0, 1.0]).rotation(FRAC_PI_2)
+                                            }
+                                            (true, false) => draw_param.rotation(FRAC_PI_2),
+                                            (false, true) => draw_param.rotation(-FRAC_PI_2),
+                                            (false, false) => {
+                                                draw_param.scale([-1.0, 1.0]).rotation(-FRAC_PI_2)
+                                            }
+                                        }
+                                    } else {
+                                        let sx = if fh { -1.0 } else { 1.0 };
+                                        let sy = if fv { -1.0 } else { 1.0 };
+                                        draw_param.scale([sx, sy])
+                                    };
+
+                                    batch.push(draw_param);
                                 }
                             }
                         }

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, f32::consts::FRAC_PI_2};
 
 use ggez::{
-    graphics::{self, Canvas, DrawParam, InstanceArray},
     Context, GameResult,
+    graphics::{self, Canvas, DrawParam, InstanceArray},
 };
 use tiled::TileLayer;
 

--- a/examples/sfml/main.rs
+++ b/examples/sfml/main.rs
@@ -63,7 +63,7 @@ impl Level {
 }
 
 /// Generates a vertex mesh from a tile layer for rendering.
-fn generate_mesh(layer: &FiniteTileLayer, tilesheet: &Tilesheet) -> QuadMesh {
+fn generate_mesh(layer: &FiniteTileLayer<'_>, tilesheet: &Tilesheet) -> QuadMesh {
     let (width, height) = (layer.width() as usize, layer.height() as usize);
     let mut mesh = QuadMesh::with_capacity(width * height);
     for x in 0..width as i32 {

--- a/examples/sfml/tilesheet.rs
+++ b/examples/sfml/tilesheet.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use sfml::{
-    graphics::{FloatRect, Texture},
     SfBox,
+    graphics::{FloatRect, Texture},
 };
 use tiled::Tileset;
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -4,7 +4,7 @@ use xml::attribute::OwnedAttribute;
 
 use crate::{
     error::{Error, Result},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{XmlEventResult, get_attrs, parse_tag},
 };
 
 /// A structure describing a [frame] of a [TMX tile animation].

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,27 +154,34 @@ impl fmt::Display for Error {
                 )
             }
             Error::InvalidTileFound => write!(fmt, "Invalid tile found in map being parsed"),
-            Error::InvalidEncodingFormat { encoding: None, compression: None } =>
-                write!(
-                    fmt,
-                    "Deprecated combination of encoding and compression"
-                ),
-            Error::InvalidEncodingFormat { encoding, compression } =>
-                write!(
-                    fmt,
-                    "Unknown encoding or compression format or invalid combination of both (for tile layers): {} encoding with {} compression",
-                    encoding.as_deref().unwrap_or("no"),
-                    compression.as_deref().unwrap_or("no")
-                ),
-            Error::InvalidPropertyValue{description} =>
-                write!(fmt, "Invalid property value: {}", description),
-            Error::UnknownPropertyType { type_name } =>
-                write!(fmt, "Unknown property value type '{}'", type_name),
-            Error::TemplateHasNoObject => write!(fmt, "A template was found with no object element"),
-            Error::InvalidWangIdEncoding{read_string} =>
-                write!(fmt, "\"{}\" is not a valid WangId format", read_string),
-            Error::InvalidObjectData{description} =>
-                write!(fmt, "Invalid object data: {}", description),
+            Error::InvalidEncodingFormat {
+                encoding: None,
+                compression: None,
+            } => write!(fmt, "Deprecated combination of encoding and compression"),
+            Error::InvalidEncodingFormat {
+                encoding,
+                compression,
+            } => write!(
+                fmt,
+                "Unknown encoding or compression format or invalid combination of both (for tile layers): {} encoding with {} compression",
+                encoding.as_deref().unwrap_or("no"),
+                compression.as_deref().unwrap_or("no")
+            ),
+            Error::InvalidPropertyValue { description } => {
+                write!(fmt, "Invalid property value: {}", description)
+            }
+            Error::UnknownPropertyType { type_name } => {
+                write!(fmt, "Unknown property value type '{}'", type_name)
+            }
+            Error::TemplateHasNoObject => {
+                write!(fmt, "A template was found with no object element")
+            }
+            Error::InvalidWangIdEncoding { read_string } => {
+                write!(fmt, "\"{}\" is not a valid WangId format", read_string)
+            }
+            Error::InvalidObjectData { description } => {
+                write!(fmt, "Invalid object data: {}", description)
+            }
             Error::InvalidTileset(e) => write!(fmt, "{}", e),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub enum CsvDecodingError {
 }
 
 impl fmt::Display for CsvDecodingError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CsvDecodingError::TileDataParseError(e) => write!(f, "{}", e),
         }
@@ -29,7 +29,7 @@ pub enum InvalidTilesetError {
 }
 
 impl fmt::Display for InvalidTilesetError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             InvalidTileDimensions => write!(
                 f,

--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::{
+    Error, Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
     error::Result,
     layers::{LayerData, LayerTag},
-    properties::{parse_properties, Properties},
+    properties::{Properties, parse_properties},
     util::*,
-    Error, Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
 };
 
 /// The raw data of a [`GroupLayer`]. Does not include a reference to its parent [`Map`](crate::Map).
@@ -121,7 +121,7 @@ impl<'map> GroupLayer<'map> {
     /// dbg!(nested_layers);
     /// # }
     /// ```
-    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'map>> + 'map {
+    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'map>> + use<'map> {
         let map: &'map crate::Map = self.map;
         self.data
             .layers

--- a/src/layers/image.rs
+++ b/src/layers/image.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, path::Path};
 
 use crate::{
-    parse_properties,
-    util::{map_wrapper, parse_tag, XmlEventResult},
-    Error, Image, Properties, Result,
+    Error, Image, Properties, Result, parse_properties,
+    util::{XmlEventResult, map_wrapper, parse_tag},
 };
 
 /// The raw data of an [`ImageLayer`]. Does not include a reference to its parent [`Map`](crate::Map).

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -3,8 +3,8 @@ use std::{path::Path, sync::Arc};
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    error::Result, properties::Properties, util::*, Color, Map, MapTilesetGid, ResourceCache,
-    ResourceReader, Tileset,
+    Color, Map, MapTilesetGid, ResourceCache, ResourceReader, Tileset, error::Result,
+    properties::Properties, util::*,
 };
 
 mod image;

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -3,10 +3,9 @@ use std::{collections::HashMap, path::Path, sync::Arc};
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
     Color, Error, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader,
-    Result, Tileset,
+    Result, Tileset, parse_properties,
+    util::{XmlEventResult, get_attrs, map_wrapper, parse_tag},
 };
 
 /// Raw data referring to a map object layer or tile collision data.

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -99,7 +99,7 @@ impl<'map> ObjectLayer<'map> {
     /// # }
     /// ```
     #[inline]
-    pub fn objects(&self) -> impl ExactSizeIterator<Item = Object<'map>> + 'map {
+    pub fn objects(&self) -> impl ExactSizeIterator<Item = Object<'map>> + use<'map> {
         let map: &'map crate::Map = self.map;
         self.data
             .objects

--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -1,8 +1,8 @@
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    util::{get_attrs, map_wrapper, XmlEventResult},
     LayerTile, LayerTileData, MapTilesetGid, Result,
+    util::{XmlEventResult, get_attrs, map_wrapper},
 };
 
 use super::util::parse_data_line;

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    util::{floor_div, get_attrs, map_wrapper, parse_tag, XmlEventResult},
     Error, LayerTile, LayerTileData, MapTilesetGid, Result,
+    util::{XmlEventResult, floor_div, get_attrs, map_wrapper, parse_tag},
 };
 
 use super::util::parse_data_line;

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
-    Error, Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset,
+    Error, Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset, parse_properties,
+    util::{XmlEventResult, get_attrs, map_wrapper, parse_tag},
 };
 
 mod finite;

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, io::Read};
 use base64::Engine;
 use xml::reader::XmlEvent;
 
-use crate::{util::XmlEventResult, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
+use crate::{CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result, util::XmlEventResult};
 
 pub(crate) fn parse_data_line(
     encoding: Option<String>,
@@ -77,7 +77,7 @@ fn decode_csv(
                         Err(e) => {
                             return Err(Error::CsvDecodingError(
                                 CsvDecodingError::TileDataParseError(e),
-                            ))
+                            ));
                         }
                     }
                 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -11,12 +11,12 @@ use std::{
 use xml::attribute::OwnedAttribute;
 
 use crate::{
+    EmbeddedParseResultType, Layer, ResourceCache, ResourceReader,
     error::{Error, Result},
     layers::{LayerData, LayerTag},
-    properties::{parse_properties, Color, Properties},
+    properties::{Color, Properties, parse_properties},
     tileset::Tileset,
-    util::{get_attrs, parse_tag, XmlEventResult},
-    EmbeddedParseResultType, Layer, ResourceCache, ResourceReader,
+    util::{XmlEventResult, get_attrs, parse_tag},
 };
 
 pub(crate) struct MapTilesetGid {
@@ -406,8 +406,11 @@ pub struct OrientationParseError {
 
 impl std::fmt::Display for OrientationParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("failed to parse orientation, valid options are `orthogonal`, `isometric`, `staggered` \
-        and `hexagonal` but got `{}` instead", self.str_found))
+        f.write_fmt(format_args!(
+            "failed to parse orientation, valid options are `orthogonal`, `isometric`, `staggered` \
+        and `hexagonal` but got `{}` instead",
+            self.str_found
+        ))
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -148,12 +148,12 @@ impl Map {
     /// # }
     /// ```
     #[inline]
-    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer> {
+    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'_>> {
         self.layers.iter().map(move |layer| Layer::new(self, layer))
     }
 
     /// Returns the top-level layer that has the specified index, if it exists.
-    pub fn get_layer(&self, index: usize) -> Option<Layer> {
+    pub fn get_layer(&self, index: usize) -> Option<Layer<'_>> {
         self.layers.get(index).map(|data| Layer::new(self, data))
     }
 }
@@ -216,7 +216,7 @@ impl Map {
                         tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset});
                     }
                     EmbeddedParseResultType::Embedded { tileset } => {
-                        tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset: Arc::new(tileset)});
+                        tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset: Arc::from(tileset)});
                     },
                 };
                 Ok(())

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -3,11 +3,11 @@ use std::{collections::HashMap, path::Path, sync::Arc};
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    error::{Error, Result},
-    properties::{parse_properties, Properties},
-    template::Template,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
     Color, Gid, MapTilesetGid, ResourceCache, ResourceReader, Tile, TileId, Tileset,
+    error::{Error, Result},
+    properties::{Properties, parse_properties},
+    template::Template,
+    util::{XmlEventResult, get_attrs, map_wrapper, parse_tag},
 };
 
 /// The location of the tileset this tile is in
@@ -507,7 +507,7 @@ impl ObjectData {
                 return Err(Error::InvalidObjectData {
                     description: "Text attribute contained anything but characters as content"
                         .into(),
-                })
+                });
             }
         };
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -353,16 +353,16 @@ impl ObjectData {
                         height: _,
                     } => ObjectShape::Text {
                         font_family: font_family.clone(),
-                        pixel_size: pixel_size.clone(),
-                        wrap: wrap.clone(),
-                        color: color.clone(),
-                        bold: bold.clone(),
-                        italic: italic.clone(),
-                        underline: underline.clone(),
-                        strikeout: strikeout.clone(),
-                        kerning: kerning.clone(),
-                        halign: halign.clone(),
-                        valign: valign.clone(),
+                        pixel_size: *pixel_size,
+                        wrap: *wrap,
+                        color: *color,
+                        bold: *bold,
+                        italic: *italic,
+                        underline: *underline,
+                        strikeout: *strikeout,
+                        kerning: *kerning,
+                        halign: *halign,
+                        valign: *valign,
                         text: text.clone(),
                         width,
                         height,
@@ -491,7 +491,7 @@ impl ObjectData {
         let italic = italic == Some(1);
         let underline = underline == Some(1);
         let strikeout = strikeout == Some(1);
-        let kerning = kerning.map_or(true, |k| k == 1);
+        let kerning = kerning.is_none_or(|k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
         let contents = match parser.next().map_or_else(

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use xml::{reader::XmlEvent, EventReader};
+use xml::{EventReader, reader::XmlEvent};
 
 use crate::{Error, Map, ResourceCache, ResourceReader, Result};
 
@@ -36,7 +36,7 @@ pub fn parse_map(
             XmlEvent::EndDocument => {
                 return Err(Error::PrematureEnd(
                     "Document ended before map was parsed".to_string(),
-                ))
+                ));
             }
             _ => {}
         }

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use xml::{reader::XmlEvent, EventReader};
+use xml::{EventReader, reader::XmlEvent};
 
 use crate::{Error, ResourceCache, ResourceReader, Result, Tileset};
 
@@ -34,7 +34,7 @@ pub fn parse_tileset(
             XmlEvent::EndDocument => {
                 return Err(Error::PrematureEnd(
                     "Tileset Document ended before map was parsed".to_string(),
-                ))
+                ));
             }
             _ => {}
         }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -4,7 +4,7 @@ use xml::{attribute::OwnedAttribute, reader::XmlEvent};
 
 use crate::{
     error::{Error, Result},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{XmlEventResult, get_attrs, parse_tag},
 };
 
 /// Represents a RGBA color with 8-bit depth on each channel.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -38,7 +38,7 @@ pub trait ResourceReader {
 }
 
 /// A [`ResourceReader`] that reads from [`File`] handles.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FilesystemResourceReader;
 
 impl FilesystemResourceReader {

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,8 +5,8 @@ use xml::EventReader;
 use xml::{attribute::OwnedAttribute, reader::XmlEvent};
 
 use crate::{
-    util::*, EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache,
-    ResourceReader, Result, Tileset,
+    EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache, ResourceReader,
+    Result, Tileset, util::*,
 };
 
 /// A template, consisting of an object and a tileset
@@ -56,7 +56,7 @@ impl Template {
                 XmlEvent::EndDocument => {
                     return Err(Error::PrematureEnd(
                         "Template Document ended before template element was parsed".to_string(),
-                    ))
+                    ));
                 }
                 _ => {}
             }

--- a/src/template.rs
+++ b/src/template.rs
@@ -91,7 +91,7 @@ impl Template {
                         });
                     }
                     EmbeddedParseResultType::Embedded { tileset: embedded_tileset } => {
-                        tileset = Some(Arc::new(embedded_tileset));
+                        tileset = Some(Arc::from(embedded_tileset));
                     },
                 };
                 tileset_gid.push(MapTilesetGid {

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -3,13 +3,13 @@ use std::{collections::HashMap, path::Path};
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    animation::{parse_animation, Frame},
+    ResourceCache, ResourceReader, Result, Tileset,
+    animation::{Frame, parse_animation},
     error::Error,
     image::Image,
     layers::ObjectLayerData,
-    properties::{parse_properties, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
-    ResourceCache, ResourceReader, Result, Tileset,
+    properties::{Properties, parse_properties},
+    util::{XmlEventResult, get_attrs, parse_tag},
 };
 
 /// A tile ID, local to a tileset.

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -5,9 +5,9 @@ use xml::attribute::OwnedAttribute;
 
 use crate::error::{Error, Result};
 use crate::image::Image;
-use crate::properties::{parse_properties, Properties};
+use crate::properties::{Properties, parse_properties};
 use crate::tile::TileData;
-use crate::{util::*, Gid, InvalidTilesetError, ResourceCache, ResourceReader, Tile, TileId};
+use crate::{Gid, InvalidTilesetError, ResourceCache, ResourceReader, Tile, TileId, util::*};
 
 mod wangset;
 pub use wangset::*;
@@ -75,7 +75,7 @@ pub struct Tileset {
 
 pub(crate) enum EmbeddedParseResultType {
     ExternalReference { tileset_path: PathBuf },
-    Embedded { tileset: Tileset },
+    Embedded { tileset: Box<Tileset> },
 }
 
 pub(crate) struct EmbeddedParseResult {
@@ -100,13 +100,13 @@ struct TilesetProperties {
 impl Tileset {
     /// Gets the tile with the specified ID from the tileset.
     #[inline]
-    pub fn get_tile(&self, id: TileId) -> Option<Tile> {
+    pub fn get_tile(&self, id: TileId) -> Option<Tile<'_>> {
         self.tiles.get(&id).map(|data| Tile::new(self, data))
     }
 
     /// Iterates through the tiles from this tileset.
     #[inline]
-    pub fn tiles(&self) -> impl ExactSizeIterator<Item = (TileId, Tile)> {
+    pub fn tiles(&self) -> impl ExactSizeIterator<Item = (TileId, Tile<'_>)> {
         self.tiles
             .iter()
             .map(move |(id, data)| (*id, Tile::new(self, data)))
@@ -178,7 +178,9 @@ impl Tileset {
         )
         .map(|tileset| EmbeddedParseResult {
             first_gid,
-            result_type: EmbeddedParseResultType::Embedded { tileset },
+            result_type: EmbeddedParseResultType::Embedded {
+                tileset: Box::new(tileset),
+            },
         })
     }
 

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    error::Error,
-    properties::{parse_properties, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
     Result, TileId,
+    error::Error,
+    properties::{Properties, parse_properties},
+    util::{XmlEventResult, get_attrs, parse_tag},
 };
 
 mod wang_color;
@@ -15,18 +15,13 @@ mod wang_tile;
 pub use wang_tile::*;
 
 /// Wang set's terrain brush connection type.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
 #[allow(missing_docs)]
 pub enum WangSetType {
     Corner,
     Edge,
+    #[default]
     Mixed,
-}
-
-impl Default for WangSetType {
-    fn default() -> Self {
-        WangSetType::Mixed
-    }
 }
 
 /// Raw data belonging to a WangSet.

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    error::Error,
-    properties::{parse_properties, Color, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
     Result, TileId,
+    error::Error,
+    properties::{Color, Properties, parse_properties},
+    util::{XmlEventResult, get_attrs, parse_tag},
 };
 
 /// Stores the data of the Wang color.

--- a/src/tileset/wangset/wang_tile.rs
+++ b/src/tileset/wangset/wang_tile.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 use xml::attribute::OwnedAttribute;
 
 use crate::{
-    error::Error,
-    util::{get_attrs, XmlEventResult},
     Result, TileId,
+    error::Error,
+    util::{XmlEventResult, get_attrs},
 };
 
 /// The Wang ID, stored as an array of 8 u8 values.

--- a/src/world.rs
+++ b/src/world.rs
@@ -3,14 +3,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use regex::Regex;
-use serde::Deserialize;
-
 use crate::{Error, ResourceReader};
 
 /// A World is a list of maps files or regex patterns that define a layout of TMX maps.
 /// You can use the loader to further load the maps defined by the world.
-#[derive(Deserialize, PartialEq, Clone, Debug)]
+#[derive(serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct World {
     /// The path first used in a [`ResourceReader`] to load this world.
     #[serde(skip_deserializing)]
@@ -54,7 +51,7 @@ impl World {
 }
 
 /// A WorldMap provides the information for a map in the world and its layout.
-#[derive(Deserialize, PartialEq, Clone, Debug)]
+#[derive(serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct WorldMap {
     /// The filename of the tmx map.
     #[serde(rename = "fileName")]
@@ -70,13 +67,13 @@ pub struct WorldMap {
 }
 
 /// A WorldPattern defines a regex pattern to automatically determine which maps to load and how to lay them out.
-#[derive(Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct WorldPattern {
     /// The regex pattern to match against filenames.
     /// The first two capture groups should be the x integer and y integer positions.
     #[serde(with = "serde_regex")]
-    pub regexp: Regex,
+    pub regexp: regex::Regex,
     /// The multiplier for the x position.
     pub multiplier_x: i32,
     /// The multiplier for the y position.
@@ -112,7 +109,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 
@@ -121,7 +118,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 
@@ -130,7 +127,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -266,7 +266,7 @@ fn test_tile_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) = r.tilesets()[0]
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) = r.tilesets()[0]
         .get_tile(1)
         .unwrap()
         .properties
@@ -284,7 +284,7 @@ fn test_layer_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) =
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) =
         r.get_layer(0).unwrap().properties.get("prop3")
     {
         v.clone()
@@ -302,7 +302,7 @@ fn test_object_group_property() {
     let group_layer = r.get_layer(1).unwrap();
     let group_layer = group_layer.as_group_layer().unwrap();
     let sub_layer = group_layer.get_layer(0).unwrap();
-    let prop_value: bool = if let Some(&PropertyValue::BoolValue(ref v)) =
+    let prop_value: bool = if let Some(PropertyValue::BoolValue(v)) =
         sub_layer.properties.get("an object group property")
     {
         *v
@@ -317,7 +317,7 @@ fn test_tileset_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) =
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) =
         r.tilesets()[0].properties.get("tileset property")
     {
         v.clone()
@@ -612,7 +612,7 @@ fn test_reading_wang_sets() {
         .unwrap();
 
     // We will pick some random data from the wangsets for tessting
-    let tileset = map.tilesets().get(0).unwrap();
+    let tileset = map.tilesets().first().unwrap();
     assert_eq!(tileset.wang_sets.len(), 3);
     let wangset_2 = tileset.wang_sets.get(1).unwrap();
     let tile_10 = wangset_2.wang_tiles.get(&10).unwrap();
@@ -649,7 +649,7 @@ fn test_text_object() {
         } => {
             assert_eq!(font_family.as_str(), "sans-serif");
             assert_eq!(*pixel_size, 16);
-            assert_eq!(*wrap, false);
+            assert!(!*wrap);
             assert_eq!(
                 *color,
                 Color {
@@ -659,11 +659,11 @@ fn test_text_object() {
                     alpha: 100
                 }
             );
-            assert_eq!(*bold, true);
-            assert_eq!(*italic, true);
-            assert_eq!(*underline, true);
-            assert_eq!(*strikeout, true);
-            assert_eq!(*kerning, true);
+            assert!(*bold);
+            assert!(*italic);
+            assert!(*underline);
+            assert!(*strikeout);
+            assert!(*kerning);
             assert_eq!(*halign, HorizontalAlignment::Center);
             assert_eq!(*valign, VerticalAlignment::Bottom);
             assert_eq!(text.as_str(), "Test");


### PR DESCRIPTION
This PR updates some code to pass clippy's standard lints and also updates the project to use Edition 2024. This happen in one PR because certain lint are only really fixable with features from the more recent compiler versions. We can actually use 1.92, for example, with edition 2018, but I think it makes sense to just be on the current edition as well.

Functionally, this PR increases the MSRV (which is unstated currently) to 1.62 at least,
which came out in mid-2022. This was required for deriving default on enumerations.
