### PR TITLE
Switch from xml-rs to quick-xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Switched from `xml-rs` to `quick-xml` to speed up XML parsing.
+
 ## [0.15.0]
 ### Added
 - New `ImageLayer` `repeat_x`/`y` fields are now parsed from map image layers. (#324)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/ggez/main.rs"
 
 [dependencies]
 base64 = "0.22.1"
-xml-rs = "0.8.4"
+quick-xml = "0.31.0"
 zstd = { version = "0.13.1", optional = true, default-features = false }
 flate2 = "1.0.28"
 serde = { version = "1.0.216", optional = true }

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -18,7 +18,7 @@ pub struct Frame {
 }
 
 impl Frame {
-    pub(crate) fn new<R: std::io::BufRead>(mut elem: XmlElement<'_, R>) -> Result<Frame> {
+    pub(crate) fn new<R: std::io::BufRead>(elem: XmlElement<'_, R>) -> Result<Frame> {
         let (tile_id, duration) = get_attrs!(
             for v in (elem.attrs) {
                 "tileid" => tile_id ?= v.parse::<u32>(),
@@ -26,17 +26,16 @@ impl Frame {
             }
             (tile_id, duration)
         );
-        parse_tag!(&mut elem, {});
+        parse_tag!(elem, {});
         Ok(Frame { tile_id, duration })
     }
 }
 
 pub(crate) fn parse_animation<R: std::io::BufRead>(
-    mut elem: XmlElement<'_, R>,
+    elem: XmlElement<'_, R>,
 ) -> Result<Vec<Frame>> {
     let mut animation = Vec::new();
-    elem.buf.clear();
-    parse_tag!(&mut elem, {
+    parse_tag!(elem, {
         "frame" => |elem| {
             animation.push(Frame::new(elem)?);
             Ok(())

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::Result,
-    util::{get_attrs, parse_tag},
+    util::{get_attrs, parse_tag, XmlElement},
 };
 
 /// A structure describing a [frame] of a [TMX tile animation].
@@ -18,27 +18,27 @@ pub struct Frame {
 }
 
 impl Frame {
-    pub(crate) fn new(attrs: quick_xml::events::BytesStart<'_>) -> Result<Frame> {
+    pub(crate) fn new<R: std::io::BufRead>(mut elem: XmlElement<'_, R>) -> Result<Frame> {
         let (tile_id, duration) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "tileid" => tile_id ?= v.parse::<u32>(),
                 "duration" => duration ?= v.parse::<u32>(),
             }
             (tile_id, duration)
         );
+        parse_tag!(&mut elem, {});
         Ok(Frame { tile_id, duration })
     }
 }
 
-pub(crate) fn parse_animation(
-    xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-    buf: &mut Vec<u8>,
+pub(crate) fn parse_animation<R: std::io::BufRead>(
+    mut elem: XmlElement<'_, R>,
 ) -> Result<Vec<Frame>> {
     let mut animation = Vec::new();
-    buf.clear();
-    parse_tag!(xml_reader, buf, "animation", {
-        "frame" => |attrs| {
-            animation.push(Frame::new(attrs)?);
+    elem.buf.clear();
+    parse_tag!(&mut elem, {
+        "frame" => |elem| {
+            animation.push(Frame::new(elem)?);
             Ok(())
         },
     });

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -1,10 +1,8 @@
 //! Structures related to tile animations.
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::{Error, Result},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    error::Result,
+    util::{get_attrs, parse_tag},
 };
 
 /// A structure describing a [frame] of a [TMX tile animation].
@@ -20,7 +18,7 @@ pub struct Frame {
 }
 
 impl Frame {
-    pub(crate) fn new(attrs: Vec<OwnedAttribute>) -> Result<Frame> {
+    pub(crate) fn new(attrs: quick_xml::events::BytesStart<'_>) -> Result<Frame> {
         let (tile_id, duration) = get_attrs!(
             for v in attrs {
                 "tileid" => tile_id ?= v.parse::<u32>(),
@@ -33,10 +31,12 @@ impl Frame {
 }
 
 pub(crate) fn parse_animation(
-    parser: &mut impl Iterator<Item = XmlEventResult>,
+    xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+    buf: &mut Vec<u8>,
 ) -> Result<Vec<Frame>> {
     let mut animation = Vec::new();
-    parse_tag!(parser, "animation", {
+    buf.clear();
+    parse_tag!(xml_reader, buf, "animation", {
         "frame" => |attrs| {
             animation.push(Frame::new(attrs)?);
             Ok(())

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -31,9 +31,7 @@ impl Frame {
     }
 }
 
-pub(crate) fn parse_animation<R: std::io::BufRead>(
-    elem: XmlElement<'_, R>,
-) -> Result<Vec<Frame>> {
+pub(crate) fn parse_animation<R: std::io::BufRead>(elem: XmlElement<'_, R>) -> Result<Vec<Frame>> {
     let mut animation = Vec::new();
     parse_tag!(elem, {
         "frame" => |elem| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,7 @@ pub enum Error {
     /// An error occurred when decoding a csv encoded dataset.
     CsvDecodingError(CsvDecodingError),
     /// An error occurred when parsing an XML file, such as a TMX or TSX file.
-    XmlDecodingError(xml::reader::Error),
+    XmlDecodingError(quick_xml::Error),
     #[cfg(feature = "world")]
     /// An error occurred when attempting to deserialize a JSON file.
     JsonDecodingError(serde_json::Error),

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,11 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::{Error, Result},
+    error::Result,
     properties::Color,
-    util::*,
+    util::{get_attrs, parse_tag},
 };
 
 /// A reference to an image stored somewhere within the filesystem.
@@ -69,21 +67,23 @@ pub struct Image {
 
 impl Image {
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         path_relative_to: impl AsRef<Path>,
     ) -> Result<Image> {
         let (c, (s, w, h)) = get_attrs!(
             for v in attrs {
                 Some("trans") => trans ?= v.parse(),
-                "source" => source = v,
+                "source" => source = v.to_string(),
                 "width" => width ?= v.parse::<i32>(),
                 "height" => height ?= v.parse::<i32>(),
             }
             (trans, (source, width, height))
         );
 
-        parse_tag!(parser, "image", {});
+        buf.clear();
+        parse_tag!(xml_reader, buf, "image", {});
         Ok(Image {
             source: path_relative_to.as_ref().join(s),
             width: w,

--- a/src/image.rs
+++ b/src/image.rs
@@ -67,7 +67,7 @@ pub struct Image {
 
 impl Image {
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: XmlElement<'_, R>,
+        elem: XmlElement<'_, R>,
         path_relative_to: impl AsRef<Path>,
     ) -> Result<Image> {
         let (c, (s, w, h)) = get_attrs!(
@@ -80,8 +80,7 @@ impl Image {
             (trans, (source, width, height))
         );
 
-        elem.buf.clear();
-        parse_tag!(&mut elem, {});
+        parse_tag!(elem, {});
         Ok(Image {
             source: path_relative_to.as_ref().join(s),
             width: w,

--- a/src/image.rs
+++ b/src/image.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::{
     error::Result,
     properties::Color,
-    util::{get_attrs, parse_tag},
+    util::{get_attrs, parse_tag, XmlElement},
 };
 
 /// A reference to an image stored somewhere within the filesystem.
@@ -66,14 +66,12 @@ pub struct Image {
 }
 
 impl Image {
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: XmlElement<'_, R>,
         path_relative_to: impl AsRef<Path>,
     ) -> Result<Image> {
         let (c, (s, w, h)) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("trans") => trans ?= v.parse(),
                 "source" => source = v.to_string(),
                 "width" => width ?= v.parse::<i32>(),
@@ -82,8 +80,8 @@ impl Image {
             (trans, (source, width, height))
         );
 
-        buf.clear();
-        parse_tag!(xml_reader, buf, "image", {});
+        elem.buf.clear();
+        parse_tag!(&mut elem, {});
         Ok(Image {
             source: path_relative_to.as_ref().join(s),
             width: w,

--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -5,7 +5,7 @@ use crate::{
     layers::{LayerData, LayerTag},
     properties::{parse_properties, Properties},
     util::*,
-    Error, Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
+    Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
 };
 
 /// The raw data of a [`GroupLayer`]. Does not include a reference to its parent [`Map`](crate::Map).
@@ -16,7 +16,8 @@ pub struct GroupLayerData {
 
 impl GroupLayerData {
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
         infinite: bool,
         map_path: &Path,
         tilesets: &[MapTilesetGid],
@@ -26,61 +27,70 @@ impl GroupLayerData {
     ) -> Result<(Self, Properties)> {
         let mut properties = HashMap::new();
         let mut layers = Vec::new();
-        parse_tag!(parser, "group", {
+        buf.clear();
+        parse_tag!(xml_reader, buf, "group", {
             "layer" => |attrs| {
                 layers.push(LayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     LayerTag::Tiles,
                     infinite,
                     map_path,
                     tilesets,
-                    for_tileset.as_ref().cloned(),reader,
+                    for_tileset.as_ref().cloned(),
+                    reader,
                     cache
                 )?);
                 Ok(())
             },
             "imagelayer" => |attrs| {
                 layers.push(LayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     LayerTag::Image,
                     infinite,
                     map_path,
                     tilesets,
-                    for_tileset.as_ref().cloned(),reader,
+                    for_tileset.as_ref().cloned(),
+                    reader,
                     cache
                 )?);
                 Ok(())
             },
             "objectgroup" => |attrs| {
                 layers.push(LayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     LayerTag::Objects,
                     infinite,
                     map_path,
                     tilesets,
-                    for_tileset.as_ref().cloned(),reader,
+                    for_tileset.as_ref().cloned(),
+                    reader,
                     cache
                 )?);
                 Ok(())
             },
             "group" => |attrs| {
                 layers.push(LayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     LayerTag::Group,
                     infinite,
                     map_path,
                     tilesets,
-                    for_tileset.as_ref().cloned(),reader,
+                    for_tileset.as_ref().cloned(),
+                    reader,
                     cache
                 )?);
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
         });

--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -16,7 +16,7 @@ pub struct GroupLayerData {
 
 impl GroupLayerData {
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         infinite: bool,
         map_path: &Path,
         tilesets: &[MapTilesetGid],
@@ -26,8 +26,7 @@ impl GroupLayerData {
     ) -> Result<(Self, Properties)> {
         let mut properties = HashMap::new();
         let mut layers = Vec::new();
-        elem.buf.clear();
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "layer" => |elem| {
                 layers.push(LayerData::new(
                     elem,

--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -15,9 +15,8 @@ pub struct GroupLayerData {
 }
 
 impl GroupLayerData {
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         infinite: bool,
         map_path: &Path,
         tilesets: &[MapTilesetGid],
@@ -27,13 +26,11 @@ impl GroupLayerData {
     ) -> Result<(Self, Properties)> {
         let mut properties = HashMap::new();
         let mut layers = Vec::new();
-        buf.clear();
-        parse_tag!(xml_reader, buf, "group", {
-            "layer" => |attrs| {
+        elem.buf.clear();
+        parse_tag!(&mut elem, {
+            "layer" => |elem| {
                 layers.push(LayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     LayerTag::Tiles,
                     infinite,
                     map_path,
@@ -44,11 +41,9 @@ impl GroupLayerData {
                 )?);
                 Ok(())
             },
-            "imagelayer" => |attrs| {
+            "imagelayer" => |elem| {
                 layers.push(LayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     LayerTag::Image,
                     infinite,
                     map_path,
@@ -59,11 +54,9 @@ impl GroupLayerData {
                 )?);
                 Ok(())
             },
-            "objectgroup" => |attrs| {
+            "objectgroup" => |elem| {
                 layers.push(LayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     LayerTag::Objects,
                     infinite,
                     map_path,
@@ -74,11 +67,9 @@ impl GroupLayerData {
                 )?);
                 Ok(())
             },
-            "group" => |attrs| {
+            "group" => |elem| {
                 layers.push(LayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     LayerTag::Group,
                     infinite,
                     map_path,
@@ -89,8 +80,8 @@ impl GroupLayerData {
                 )?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/layers/image.rs
+++ b/src/layers/image.rs
@@ -19,7 +19,7 @@ pub struct ImageLayerData {
 
 impl ImageLayerData {
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         map_path: &Path,
     ) -> Result<(Self, Properties)> {
         let mut image: Option<Image> = None;
@@ -35,9 +35,8 @@ impl ImageLayerData {
             }
             (repeat_x, repeat_y)
         );
-        elem.buf.clear();
 
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "image" => |elem| {
                 image = Some(Image::new(elem, path_relative_to)?);
                 Ok(())

--- a/src/layers/image.rs
+++ b/src/layers/image.rs
@@ -18,10 +18,8 @@ pub struct ImageLayerData {
 }
 
 impl ImageLayerData {
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         map_path: &Path,
     ) -> Result<(Self, Properties)> {
         let mut image: Option<Image> = None;
@@ -31,21 +29,21 @@ impl ImageLayerData {
 
         // Parse repeat attributes from the imagelayer tag
         let (repeat_x, repeat_y) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("repeatx") => repeat_x ?= v.parse::<i32>().map(|val| val == 1),
                 Some("repeaty") => repeat_y ?= v.parse::<i32>().map(|val| val == 1),
             }
             (repeat_x, repeat_y)
         );
-        buf.clear();
+        elem.buf.clear();
 
-        parse_tag!(xml_reader, buf, "imagelayer", {
-            "image" => |attrs| {
-                image = Some(Image::new(xml_reader, buf, attrs, path_relative_to)?);
+        parse_tag!(&mut elem, {
+            "image" => |elem| {
+                image = Some(Image::new(elem, path_relative_to)?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/layers/image.rs
+++ b/src/layers/image.rs
@@ -1,10 +1,8 @@
 use std::{collections::HashMap, path::Path};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
+    util::{get_attrs, map_wrapper, parse_tag},
     Error, Image, Properties, Result,
 };
 
@@ -21,8 +19,9 @@ pub struct ImageLayerData {
 
 impl ImageLayerData {
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         map_path: &Path,
     ) -> Result<(Self, Properties)> {
         let mut image: Option<Image> = None;
@@ -38,14 +37,15 @@ impl ImageLayerData {
             }
             (repeat_x, repeat_y)
         );
+        buf.clear();
 
-        parse_tag!(parser, "imagelayer", {
+        parse_tag!(xml_reader, buf, "imagelayer", {
             "image" => |attrs| {
-                image = Some(Image::new(parser, attrs, path_relative_to)?);
+                image = Some(Image::new(xml_reader, buf, attrs, path_relative_to)?);
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
         });

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -1,7 +1,5 @@
 use std::{path::Path, sync::Arc};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     error::Result, properties::Properties, util::*, Color, Map, MapTilesetGid, ResourceCache,
     ResourceReader, Tileset,
@@ -68,8 +66,9 @@ impl LayerData {
     }
 
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         tag: LayerTag,
         infinite: bool,
         map_path: &Path,
@@ -99,22 +98,24 @@ impl LayerData {
                 Some("offsety") => offset_y ?= v.parse(),
                 Some("parallaxx") => parallax_x ?= v.parse(),
                 Some("parallaxy") => parallax_y ?= v.parse(),
-                Some("name") => name = v,
+                Some("name") => name = v.to_string(),
                 Some("id") => id ?= v.parse(),
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
             }
             (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type, user_class)
         );
+        buf.clear();
 
         let (ty, properties) = match tag {
             LayerTag::Tiles => {
-                let (ty, properties) = TileLayerData::new(parser, attrs, infinite, tilesets)?;
+                let (ty, properties) = TileLayerData::new(xml_reader, buf, attrs, infinite, tilesets)?;
                 (LayerDataType::Tiles(ty), properties)
             }
             LayerTag::Objects => {
                 let (ty, properties) = ObjectLayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     Some(tilesets),
                     for_tileset,
@@ -125,12 +126,13 @@ impl LayerData {
                 (LayerDataType::Objects(ty), properties)
             }
             LayerTag::Image => {
-                let (ty, properties) = ImageLayerData::new(parser, attrs, map_path)?;
+                let (ty, properties) = ImageLayerData::new(xml_reader, buf, attrs, map_path)?;
                 (LayerDataType::Image(ty), properties)
             }
             LayerTag::Group => {
                 let (ty, properties) = GroupLayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     infinite,
                     map_path,
                     tilesets,

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -65,10 +65,8 @@ impl LayerData {
         self.id
     }
 
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         tag: LayerTag,
         infinite: bool,
         map_path: &Path,
@@ -90,7 +88,7 @@ impl LayerData {
             user_type,
             user_class,
         ) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("opacity") => opacity ?= v.parse(),
                 Some("tintcolor") => tint_color ?= v.parse(),
                 Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
@@ -105,18 +103,16 @@ impl LayerData {
             }
             (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type, user_class)
         );
-        buf.clear();
+        elem.buf.clear();
 
         let (ty, properties) = match tag {
             LayerTag::Tiles => {
-                let (ty, properties) = TileLayerData::new(xml_reader, buf, attrs, infinite, tilesets)?;
+                let (ty, properties) = TileLayerData::new(elem, infinite, tilesets)?;
                 (LayerDataType::Tiles(ty), properties)
             }
             LayerTag::Objects => {
                 let (ty, properties) = ObjectLayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     Some(tilesets),
                     for_tileset,
                     map_path.parent().ok_or(crate::Error::PathIsNotFile)?,
@@ -126,13 +122,12 @@ impl LayerData {
                 (LayerDataType::Objects(ty), properties)
             }
             LayerTag::Image => {
-                let (ty, properties) = ImageLayerData::new(xml_reader, buf, attrs, map_path)?;
+                let (ty, properties) = ImageLayerData::new(elem, map_path)?;
                 (LayerDataType::Image(ty), properties)
             }
             LayerTag::Group => {
                 let (ty, properties) = GroupLayerData::new(
-                    xml_reader,
-                    buf,
+                    elem,
                     infinite,
                     map_path,
                     tilesets,

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -103,7 +103,6 @@ impl LayerData {
             }
             (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type, user_class)
         );
-        elem.buf.clear();
 
         let (ty, properties) = match tag {
             LayerTag::Tiles => {

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -18,10 +18,8 @@ pub struct ObjectLayerData {
 impl ObjectLayerData {
     /// If it is known that there are no objects with tile images in it (i.e. collision data)
     /// then we can pass in [`None`] as the tilesets
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         tilesets: Option<&[MapTilesetGid]>,
         for_tileset: Option<Arc<Tileset>>,
         // path_relative_to is a directory to which all other files are relative to
@@ -30,21 +28,21 @@ impl ObjectLayerData {
         cache: &mut impl ResourceCache,
     ) -> Result<(ObjectLayerData, Properties)> {
         let c = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("color") => color ?= v.parse(),
             }
             color
         );
-        buf.clear();
+        elem.buf.clear();
         let mut objects = Vec::new();
         let mut properties = HashMap::new();
-        parse_tag!(xml_reader, buf, "objectgroup", {
-            "object" => |attrs| {
-                objects.push(ObjectData::new(xml_reader, buf, attrs, tilesets, for_tileset.as_ref().cloned(), path_relative_to, reader, cache)?);
+        parse_tag!(&mut elem, {
+            "object" => |elem| {
+                objects.push(ObjectData::new(elem, tilesets, for_tileset.as_ref().cloned(), path_relative_to, reader, cache)?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -1,11 +1,9 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
-    Color, Error, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader,
+    util::{get_attrs, map_wrapper, parse_tag},
+    Color, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader,
     Result, Tileset,
 };
 
@@ -21,8 +19,9 @@ impl ObjectLayerData {
     /// If it is known that there are no objects with tile images in it (i.e. collision data)
     /// then we can pass in [`None`] as the tilesets
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         tilesets: Option<&[MapTilesetGid]>,
         for_tileset: Option<Arc<Tileset>>,
         // path_relative_to is a directory to which all other files are relative to
@@ -36,15 +35,16 @@ impl ObjectLayerData {
             }
             color
         );
+        buf.clear();
         let mut objects = Vec::new();
         let mut properties = HashMap::new();
-        parse_tag!(parser, "objectgroup", {
+        parse_tag!(xml_reader, buf, "objectgroup", {
             "object" => |attrs| {
-                objects.push(ObjectData::new(parser, attrs, tilesets, for_tileset.as_ref().cloned(), path_relative_to, reader, cache)?);
+                objects.push(ObjectData::new(xml_reader, buf, attrs, tilesets, for_tileset.as_ref().cloned(), path_relative_to, reader, cache)?);
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
         });

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -19,7 +19,7 @@ impl ObjectLayerData {
     /// If it is known that there are no objects with tile images in it (i.e. collision data)
     /// then we can pass in [`None`] as the tilesets
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         tilesets: Option<&[MapTilesetGid]>,
         for_tileset: Option<Arc<Tileset>>,
         // path_relative_to is a directory to which all other files are relative to
@@ -33,10 +33,9 @@ impl ObjectLayerData {
             }
             color
         );
-        elem.buf.clear();
         let mut objects = Vec::new();
         let mut properties = HashMap::new();
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "object" => |elem| {
                 objects.push(ObjectData::new(elem, tilesets, for_tileset.as_ref().cloned(), path_relative_to, reader, cache)?);
                 Ok(())

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, path::Path, sync::Arc};
 use crate::{
     parse_properties,
     util::{get_attrs, map_wrapper, parse_tag},
-    Color, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader,
-    Result, Tileset,
+    Color, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader, Result,
+    Tileset,
 };
 
 /// Raw data referring to a map object layer or tile collision data.

--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -36,24 +36,22 @@ impl FiniteTileLayerData {
         self.height
     }
 
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         width: u32,
         height: u32,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("encoding") => encoding = v.to_string(),
                 Some("compression") => compression = v.to_string(),
             }
             (encoding, compression)
         );
-        buf.clear();
+        elem.buf.clear();
 
-        let tiles = parse_data_line(e, c, xml_reader, buf, tilesets)?;
+        let tiles = parse_data_line(e, c, elem, tilesets)?;
 
         Ok(Self {
             width,

--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -1,7 +1,5 @@
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    util::{get_attrs, map_wrapper, XmlEventResult},
+    util::{get_attrs, map_wrapper},
     LayerTile, LayerTileData, MapTilesetGid, Result,
 };
 
@@ -39,21 +37,23 @@ impl FiniteTileLayerData {
     }
 
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         width: u32,
         height: u32,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
             for v in attrs {
-                Some("encoding") => encoding = v,
-                Some("compression") => compression = v,
+                Some("encoding") => encoding = v.to_string(),
+                Some("compression") => compression = v.to_string(),
             }
             (encoding, compression)
         );
+        buf.clear();
 
-        let tiles = parse_data_line(e, c, parser, tilesets)?;
+        let tiles = parse_data_line(e, c, xml_reader, buf, tilesets)?;
 
         Ok(Self {
             width,

--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -49,7 +49,6 @@ impl FiniteTileLayerData {
             }
             (encoding, compression)
         );
-        elem.buf.clear();
 
         let tiles = parse_data_line(e, c, elem, tilesets)?;
 

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -21,7 +21,7 @@ impl std::fmt::Debug for InfiniteTileLayerData {
 
 impl InfiniteTileLayerData {
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
@@ -31,10 +31,9 @@ impl InfiniteTileLayerData {
             }
             (encoding, compression)
         );
-        elem.buf.clear();
 
         let mut chunks = HashMap::<(i32, i32), ChunkData>::new();
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "chunk" => |elem| {
                 let chunk = InternalChunk::new(elem, e.clone(), c.clone(), tilesets)?;
                 for x in chunk.x..chunk.x + chunk.width as i32 {
@@ -197,7 +196,6 @@ impl InternalChunk {
             }
             (x, y, width, height)
         );
-        elem.buf.clear();
 
         let tiles = parse_data_line(encoding, compression, elem, tilesets)?;
 

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -20,25 +20,23 @@ impl std::fmt::Debug for InfiniteTileLayerData {
 }
 
 impl InfiniteTileLayerData {
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("encoding") => encoding = v.to_string(),
                 Some("compression") => compression = v.to_string(),
             }
             (encoding, compression)
         );
-        buf.clear();
+        elem.buf.clear();
 
         let mut chunks = HashMap::<(i32, i32), ChunkData>::new();
-        parse_tag!(xml_reader, buf, "data", {
-            "chunk" => |attrs| {
-                let chunk = InternalChunk::new(xml_reader, buf, attrs, e.clone(), c.clone(), tilesets)?;
+        parse_tag!(&mut elem, {
+            "chunk" => |elem| {
+                let chunk = InternalChunk::new(elem, e.clone(), c.clone(), tilesets)?;
                 for x in chunk.x..chunk.x + chunk.width as i32 {
                     for y in chunk.y..chunk.y + chunk.height as i32 {
                         let chunk_pos = ChunkData::tile_to_chunk_pos(x, y);
@@ -184,16 +182,14 @@ struct InternalChunk {
 }
 
 impl InternalChunk {
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         encoding: Option<String>,
         compression: Option<String>,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (x, y, width, height) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "x" => x ?= v.parse::<i32>(),
                 "y" => y ?= v.parse::<i32>(),
                 "width" => width ?= v.parse::<u32>(),
@@ -201,9 +197,9 @@ impl InternalChunk {
             }
             (x, y, width, height)
         );
-        buf.clear();
+        elem.buf.clear();
 
-        let tiles = parse_data_line(encoding, compression, xml_reader, buf, tilesets)?;
+        let tiles = parse_data_line(encoding, compression, elem, tilesets)?;
 
         Ok(InternalChunk {
             x,

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    util::{floor_div, get_attrs, map_wrapper, parse_tag, XmlEventResult},
+    util::{floor_div, get_attrs, map_wrapper, parse_tag},
     Error, LayerTile, LayerTileData, MapTilesetGid, Result,
 };
 
@@ -23,22 +21,24 @@ impl std::fmt::Debug for InfiniteTileLayerData {
 
 impl InfiniteTileLayerData {
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
             for v in attrs {
-                Some("encoding") => encoding = v,
-                Some("compression") => compression = v,
+                Some("encoding") => encoding = v.to_string(),
+                Some("compression") => compression = v.to_string(),
             }
             (encoding, compression)
         );
+        buf.clear();
 
         let mut chunks = HashMap::<(i32, i32), ChunkData>::new();
-        parse_tag!(parser, "data", {
+        parse_tag!(xml_reader, buf, "data", {
             "chunk" => |attrs| {
-                let chunk = InternalChunk::new(parser, attrs, e.clone(), c.clone(), tilesets)?;
+                let chunk = InternalChunk::new(xml_reader, buf, attrs, e.clone(), c.clone(), tilesets)?;
                 for x in chunk.x..chunk.x + chunk.width as i32 {
                     for y in chunk.y..chunk.y + chunk.height as i32 {
                         let chunk_pos = ChunkData::tile_to_chunk_pos(x, y);
@@ -185,8 +185,9 @@ struct InternalChunk {
 
 impl InternalChunk {
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         encoding: Option<String>,
         compression: Option<String>,
         tilesets: &[MapTilesetGid],
@@ -200,8 +201,9 @@ impl InternalChunk {
             }
             (x, y, width, height)
         );
+        buf.clear();
 
-        let tiles = parse_data_line(encoding, compression, parser, tilesets)?;
+        let tiles = parse_data_line(encoding, compression, xml_reader, buf, tilesets)?;
 
         Ok(InternalChunk {
             x,

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
-    Error, Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset,
+    util::{get_attrs, map_wrapper, parse_tag},
+    Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset,
 };
 
 mod finite;
@@ -95,8 +93,9 @@ pub(crate) enum TileLayerData {
 
 impl TileLayerData {
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         infinite: bool,
         tilesets: &[MapTilesetGid],
     ) -> Result<(Self, Properties)> {
@@ -107,19 +106,20 @@ impl TileLayerData {
             }
             (width, height)
         );
+        buf.clear();
         let mut result = Self::Finite(Default::default());
         let mut properties = HashMap::new();
-        parse_tag!(parser, "layer", {
+        parse_tag!(xml_reader, buf, "layer", {
             "data" => |attrs| {
                 if infinite {
-                    result = Self::Infinite(InfiniteTileLayerData::new(parser, attrs, tilesets)?);
+                    result = Self::Infinite(InfiniteTileLayerData::new(xml_reader, buf, attrs, tilesets)?);
                 } else {
-                    result = Self::Finite(FiniteTileLayerData::new(parser, attrs, width, height, tilesets)?);
+                    result = Self::Finite(FiniteTileLayerData::new(xml_reader, buf, attrs, width, height, tilesets)?);
                 }
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
         });

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -92,34 +92,32 @@ pub(crate) enum TileLayerData {
 }
 
 impl TileLayerData {
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         infinite: bool,
         tilesets: &[MapTilesetGid],
     ) -> Result<(Self, Properties)> {
         let (width, height) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "width" => width ?= v.parse::<u32>(),
                 "height" => height ?= v.parse::<u32>(),
             }
             (width, height)
         );
-        buf.clear();
+        elem.buf.clear();
         let mut result = Self::Finite(Default::default());
         let mut properties = HashMap::new();
-        parse_tag!(xml_reader, buf, "layer", {
-            "data" => |attrs| {
+        parse_tag!(&mut elem, {
+            "data" => |elem| {
                 if infinite {
-                    result = Self::Infinite(InfiniteTileLayerData::new(xml_reader, buf, attrs, tilesets)?);
+                    result = Self::Infinite(InfiniteTileLayerData::new(elem, tilesets)?);
                 } else {
-                    result = Self::Finite(FiniteTileLayerData::new(xml_reader, buf, attrs, width, height, tilesets)?);
+                    result = Self::Finite(FiniteTileLayerData::new(elem, width, height, tilesets)?);
                 }
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -93,7 +93,7 @@ pub(crate) enum TileLayerData {
 
 impl TileLayerData {
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         infinite: bool,
         tilesets: &[MapTilesetGid],
     ) -> Result<(Self, Properties)> {
@@ -104,10 +104,9 @@ impl TileLayerData {
             }
             (width, height)
         );
-        elem.buf.clear();
         let mut result = Self::Finite(Default::default());
         let mut properties = HashMap::new();
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "data" => |elem| {
                 if infinite {
                     result = Self::Infinite(InfiniteTileLayerData::new(elem, tilesets)?);

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -12,32 +12,20 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
     elem: crate::util::XmlElement<'_, R>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
-    if elem.is_empty {
-        return match (encoding.as_deref(), compression.as_deref()) {
-            (Some("csv"), None)
-            | (Some("base64"), None)
-            | (Some("base64"), Some("zlib"))
-            | (Some("base64"), Some("gzip")) => Ok(Vec::new()),
-            #[cfg(feature = "zstd")]
-            (Some("base64"), Some("zstd")) => Ok(Vec::new()),
-            _ => Err(Error::InvalidEncodingFormat {
-                encoding,
-                compression,
-            }),
-        };
-    }
+    let text = read_text_or_cdata(elem, "Ran out of XML data")?;
+    let text = text.as_deref().unwrap_or("");
     match (encoding.as_deref(), compression.as_deref()) {
-        (Some("csv"), None) => decode_csv(elem, tilesets),
+        (Some("csv"), None) => decode_csv(text, tilesets),
 
-        (Some("base64"), None) => parse_base64(elem).map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("zlib")) => parse_base64(elem)
+        (Some("base64"), None) => parse_base64(text).map(|v| convert_to_tiles(&v, tilesets)),
+        (Some("base64"), Some("zlib")) => parse_base64(text)
             .and_then(|data| process_decoder(Ok(flate2::bufread::ZlibDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("gzip")) => parse_base64(elem)
+        (Some("base64"), Some("gzip")) => parse_base64(text)
             .and_then(|data| process_decoder(Ok(flate2::bufread::GzDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
         #[cfg(feature = "zstd")]
-        (Some("base64"), Some("zstd")) => parse_base64(elem)
+        (Some("base64"), Some("zstd")) => parse_base64(text)
             .and_then(|data| process_decoder(zstd::stream::read::Decoder::with_buffer(&data[..])))
             .map(|v| convert_to_tiles(&v, tilesets)),
 
@@ -48,12 +36,7 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
     }
 }
 
-fn parse_base64<R: std::io::BufRead>(elem: crate::util::XmlElement<'_, R>) -> Result<Vec<u8>> {
-    let text = match read_text_or_cdata(elem, "Ran out of XML data")? {
-        Some(text) => text,
-        None => return Ok(Vec::new()),
-    };
-
+fn parse_base64(text: &str) -> Result<Vec<u8>> {
     base64::engine::GeneralPurpose::new(
         &base64::alphabet::STANDARD,
         base64::engine::general_purpose::PAD,
@@ -72,15 +55,7 @@ fn process_decoder(decoder: std::io::Result<impl Read>) -> Result<Vec<u8>> {
         .map_err(Error::DecompressingError)
 }
 
-fn decode_csv<R: std::io::BufRead>(
-    elem: crate::util::XmlElement<'_, R>,
-    tilesets: &[MapTilesetGid],
-) -> Result<Vec<Option<LayerTileData>>> {
-    let text = match read_text_or_cdata(elem, "Ran out of XML data")? {
-        Some(text) => text,
-        None => return Ok(Vec::new()),
-    };
-
+fn decode_csv(text: &str, tilesets: &[MapTilesetGid]) -> Result<Vec<Option<LayerTileData>>> {
     let mut tiles = Vec::new();
     for v in text.split(',') {
         match v.trim().parse() {

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -5,25 +5,40 @@ use quick_xml::events::Event;
 
 use crate::{CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
 
-pub(crate) fn parse_data_line(
+pub(crate) fn parse_data_line<R: std::io::BufRead>(
     encoding: Option<String>,
     compression: Option<String>,
-    reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-    buf: &mut Vec<u8>,
+    mut elem: crate::util::XmlElement<'_, R>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
+    if elem.is_empty {
+        return match (encoding.as_deref(), compression.as_deref()) {
+            (Some("csv"), None)
+            | (Some("base64"), None)
+            | (Some("base64"), Some("zlib"))
+            | (Some("base64"), Some("gzip")) => Ok(Vec::new()),
+            #[cfg(feature = "zstd")]
+            (Some("base64"), Some("zstd")) => Ok(Vec::new()),
+            _ => Err(Error::InvalidEncodingFormat {
+                encoding,
+                compression,
+            }),
+        };
+    }
     match (encoding.as_deref(), compression.as_deref()) {
-        (Some("csv"), None) => decode_csv(reader, buf, tilesets),
+        (Some("csv"), None) => decode_csv(&mut elem, tilesets),
 
-        (Some("base64"), None) => parse_base64(reader, buf).map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("zlib")) => parse_base64(reader, buf)
+        (Some("base64"), None) => {
+            parse_base64(&mut elem).map(|v| convert_to_tiles(&v, tilesets))
+        }
+        (Some("base64"), Some("zlib")) => parse_base64(&mut elem)
             .and_then(|data| process_decoder(Ok(flate2::bufread::ZlibDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("gzip")) => parse_base64(reader, buf)
+        (Some("base64"), Some("gzip")) => parse_base64(&mut elem)
             .and_then(|data| process_decoder(Ok(flate2::bufread::GzDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
         #[cfg(feature = "zstd")]
-        (Some("base64"), Some("zstd")) => parse_base64(reader, buf)
+        (Some("base64"), Some("zstd")) => parse_base64(&mut elem)
             .and_then(|data| process_decoder(zstd::stream::read::Decoder::with_buffer(&data[..])))
             .map(|v| convert_to_tiles(&v, tilesets)),
 
@@ -34,43 +49,48 @@ pub(crate) fn parse_data_line(
     }
 }
 
-fn parse_base64(
-    reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-    buf: &mut Vec<u8>,
+fn parse_base64<R: std::io::BufRead>(
+    elem: &mut crate::util::XmlElement<'_, R>,
 ) -> Result<Vec<u8>> {
+    let mut text = None;
     loop {
-        match reader.read_event_into(buf).map_err(Error::XmlDecodingError)? {
+        match elem
+            .reader
+            .read_event_into(elem.buf)
+            .map_err(Error::XmlDecodingError)?
+        {
             Event::Text(e) => {
-                let text = e.unescape().map_err(Error::XmlDecodingError)?.into_owned();
-                buf.clear();
-                return base64::engine::GeneralPurpose::new(
-                    &base64::alphabet::STANDARD,
-                    base64::engine::general_purpose::PAD,
-                )
-                .decode(text.trim().as_bytes())
-                .map_err(Error::Base64DecodingError);
+                text = Some(e.unescape().map_err(Error::XmlDecodingError)?.into_owned());
+                elem.buf.clear();
             }
             Event::CData(e) => {
-                let text = String::from_utf8_lossy(e.as_ref()).into_owned();
-                buf.clear();
-                return base64::engine::GeneralPurpose::new(
-                    &base64::alphabet::STANDARD,
-                    base64::engine::general_purpose::PAD,
-                )
-                .decode(text.trim().as_bytes())
-                .map_err(Error::Base64DecodingError);
+                text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
+                elem.buf.clear();
             }
-            Event::End(ref e) if e.local_name().as_ref() == b"data" => {
-                buf.clear();
-                return Ok(Vec::new());
+            Event::End(_) => {
+                elem.buf.clear();
+                break;
             }
             Event::Eof => {
                 return Err(Error::PrematureEnd("Ran out of XML data".to_owned()));
             }
-            _ => {}
+            _ => {
+                elem.buf.clear();
+            }
         }
-        buf.clear();
     }
+
+    let text = match text {
+        Some(text) => text,
+        None => return Ok(Vec::new()),
+    };
+
+    base64::engine::GeneralPurpose::new(
+        &base64::alphabet::STANDARD,
+        base64::engine::general_purpose::PAD,
+    )
+    .decode(text.trim().as_bytes())
+    .map_err(Error::Base64DecodingError)
 }
 
 fn process_decoder(decoder: std::io::Result<impl Read>) -> Result<Vec<u8>> {
@@ -83,56 +103,55 @@ fn process_decoder(decoder: std::io::Result<impl Read>) -> Result<Vec<u8>> {
         .map_err(Error::DecompressingError)
 }
 
-fn decode_csv(
-    reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-    buf: &mut Vec<u8>,
+fn decode_csv<R: std::io::BufRead>(
+    elem: &mut crate::util::XmlElement<'_, R>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
+    let mut text = None;
     loop {
-        match reader.read_event_into(buf).map_err(Error::XmlDecodingError)? {
+        match elem
+            .reader
+            .read_event_into(elem.buf)
+            .map_err(Error::XmlDecodingError)?
+        {
             Event::Text(e) => {
-                let text = e.unescape().map_err(Error::XmlDecodingError)?.into_owned();
-                buf.clear();
-                let mut tiles = Vec::new();
-                for v in text.split(',') {
-                    match v.trim().parse() {
-                        Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
-                        Err(e) => {
-                            return Err(Error::CsvDecodingError(
-                                CsvDecodingError::TileDataParseError(e),
-                            ))
-                        }
-                    }
-                }
-                return Ok(tiles);
+                text = Some(e.unescape().map_err(Error::XmlDecodingError)?.into_owned());
+                elem.buf.clear();
             }
             Event::CData(e) => {
-                let text = String::from_utf8_lossy(e.as_ref()).into_owned();
-                buf.clear();
-                let mut tiles = Vec::new();
-                for v in text.split(',') {
-                    match v.trim().parse() {
-                        Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
-                        Err(e) => {
-                            return Err(Error::CsvDecodingError(
-                                CsvDecodingError::TileDataParseError(e),
-                            ))
-                        }
-                    }
-                }
-                return Ok(tiles);
+                text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
+                elem.buf.clear();
             }
-            Event::End(ref e) if e.local_name().as_ref() == b"data" => {
-                buf.clear();
-                return Ok(Vec::new());
+            Event::End(_) => {
+                elem.buf.clear();
+                break;
             }
             Event::Eof => {
                 return Err(Error::PrematureEnd("Ran out of XML data".to_owned()));
             }
-            _ => {}
+            _ => {
+                elem.buf.clear();
+            }
         }
-        buf.clear();
     }
+
+    let text = match text {
+        Some(text) => text,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut tiles = Vec::new();
+    for v in text.split(',') {
+        match v.trim().parse() {
+            Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
+            Err(e) => {
+                return Err(Error::CsvDecodingError(
+                    CsvDecodingError::TileDataParseError(e),
+                ))
+            }
+        }
+    }
+    Ok(tiles)
 }
 
 fn convert_to_tiles(data: &[u8], tilesets: &[MapTilesetGid]) -> Vec<Option<LayerTileData>> {

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -2,7 +2,9 @@ use std::{convert::TryInto, io::Read};
 
 use base64::Engine;
 
-use crate::{util::read_text_or_cdata, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
+use crate::{
+    util::read_text_or_cdata, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result,
+};
 
 pub(crate) fn parse_data_line<R: std::io::BufRead>(
     encoding: Option<String>,
@@ -27,9 +29,7 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
     match (encoding.as_deref(), compression.as_deref()) {
         (Some("csv"), None) => decode_csv(&mut elem, tilesets),
 
-        (Some("base64"), None) => {
-            parse_base64(&mut elem).map(|v| convert_to_tiles(&v, tilesets))
-        }
+        (Some("base64"), None) => parse_base64(&mut elem).map(|v| convert_to_tiles(&v, tilesets)),
         (Some("base64"), Some("zlib")) => parse_base64(&mut elem)
             .and_then(|data| process_decoder(Ok(flate2::bufread::ZlibDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
@@ -48,9 +48,7 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
     }
 }
 
-fn parse_base64<R: std::io::BufRead>(
-    elem: &mut crate::util::XmlElement<'_, R>,
-) -> Result<Vec<u8>> {
+fn parse_base64<R: std::io::BufRead>(elem: &mut crate::util::XmlElement<'_, R>) -> Result<Vec<u8>> {
     let text = match read_text_or_cdata(elem, "Ran out of XML data")? {
         Some(text) => text,
         None => return Ok(Vec::new()),

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -48,9 +48,7 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
     }
 }
 
-fn parse_base64<R: std::io::BufRead>(
-    elem: crate::util::XmlElement<'_, R>,
-) -> Result<Vec<u8>> {
+fn parse_base64<R: std::io::BufRead>(elem: crate::util::XmlElement<'_, R>) -> Result<Vec<u8>> {
     let text = match read_text_or_cdata(elem, "Ran out of XML data")? {
         Some(text) => text,
         None => return Ok(Vec::new()),

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -1,28 +1,29 @@
 use std::{convert::TryInto, io::Read};
 
 use base64::Engine;
-use xml::reader::XmlEvent;
+use quick_xml::events::Event;
 
-use crate::{util::XmlEventResult, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
+use crate::{CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
 
 pub(crate) fn parse_data_line(
     encoding: Option<String>,
     compression: Option<String>,
-    parser: &mut impl Iterator<Item = XmlEventResult>,
+    reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+    buf: &mut Vec<u8>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
     match (encoding.as_deref(), compression.as_deref()) {
-        (Some("csv"), None) => decode_csv(parser, tilesets),
+        (Some("csv"), None) => decode_csv(reader, buf, tilesets),
 
-        (Some("base64"), None) => parse_base64(parser).map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("zlib")) => parse_base64(parser)
+        (Some("base64"), None) => parse_base64(reader, buf).map(|v| convert_to_tiles(&v, tilesets)),
+        (Some("base64"), Some("zlib")) => parse_base64(reader, buf)
             .and_then(|data| process_decoder(Ok(flate2::bufread::ZlibDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("gzip")) => parse_base64(parser)
+        (Some("base64"), Some("gzip")) => parse_base64(reader, buf)
             .and_then(|data| process_decoder(Ok(flate2::bufread::GzDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
         #[cfg(feature = "zstd")]
-        (Some("base64"), Some("zstd")) => parse_base64(parser)
+        (Some("base64"), Some("zstd")) => parse_base64(reader, buf)
             .and_then(|data| process_decoder(zstd::stream::read::Decoder::with_buffer(&data[..])))
             .map(|v| convert_to_tiles(&v, tilesets)),
 
@@ -33,24 +34,43 @@ pub(crate) fn parse_data_line(
     }
 }
 
-fn parse_base64(parser: &mut impl Iterator<Item = XmlEventResult>) -> Result<Vec<u8>> {
-    for next in parser {
-        match next.map_err(Error::XmlDecodingError)? {
-            XmlEvent::Characters(s) => {
+fn parse_base64(
+    reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+    buf: &mut Vec<u8>,
+) -> Result<Vec<u8>> {
+    loop {
+        match reader.read_event_into(buf).map_err(Error::XmlDecodingError)? {
+            Event::Text(e) => {
+                let text = e.unescape().map_err(Error::XmlDecodingError)?.into_owned();
+                buf.clear();
                 return base64::engine::GeneralPurpose::new(
                     &base64::alphabet::STANDARD,
                     base64::engine::general_purpose::PAD,
                 )
-                .decode(s.trim().as_bytes())
+                .decode(text.trim().as_bytes())
                 .map_err(Error::Base64DecodingError);
             }
-            XmlEvent::EndElement { name, .. } if name.local_name == "data" => {
+            Event::CData(e) => {
+                let text = String::from_utf8_lossy(e.as_ref()).into_owned();
+                buf.clear();
+                return base64::engine::GeneralPurpose::new(
+                    &base64::alphabet::STANDARD,
+                    base64::engine::general_purpose::PAD,
+                )
+                .decode(text.trim().as_bytes())
+                .map_err(Error::Base64DecodingError);
+            }
+            Event::End(ref e) if e.local_name().as_ref() == b"data" => {
+                buf.clear();
                 return Ok(Vec::new());
+            }
+            Event::Eof => {
+                return Err(Error::PrematureEnd("Ran out of XML data".to_owned()));
             }
             _ => {}
         }
+        buf.clear();
     }
-    Err(Error::PrematureEnd("Ran out of XML data".to_owned()))
 }
 
 fn process_decoder(decoder: std::io::Result<impl Read>) -> Result<Vec<u8>> {
@@ -64,14 +84,17 @@ fn process_decoder(decoder: std::io::Result<impl Read>) -> Result<Vec<u8>> {
 }
 
 fn decode_csv(
-    parser: &mut impl Iterator<Item = XmlEventResult>,
+    reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+    buf: &mut Vec<u8>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
-    for next in parser {
-        match next.map_err(Error::XmlDecodingError)? {
-            XmlEvent::Characters(s) => {
+    loop {
+        match reader.read_event_into(buf).map_err(Error::XmlDecodingError)? {
+            Event::Text(e) => {
+                let text = e.unescape().map_err(Error::XmlDecodingError)?.into_owned();
+                buf.clear();
                 let mut tiles = Vec::new();
-                for v in s.split(',') {
+                for v in text.split(',') {
                     match v.trim().parse() {
                         Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
                         Err(e) => {
@@ -83,13 +106,33 @@ fn decode_csv(
                 }
                 return Ok(tiles);
             }
-            XmlEvent::EndElement { name, .. } if name.local_name == "data" => {
+            Event::CData(e) => {
+                let text = String::from_utf8_lossy(e.as_ref()).into_owned();
+                buf.clear();
+                let mut tiles = Vec::new();
+                for v in text.split(',') {
+                    match v.trim().parse() {
+                        Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
+                        Err(e) => {
+                            return Err(Error::CsvDecodingError(
+                                CsvDecodingError::TileDataParseError(e),
+                            ))
+                        }
+                    }
+                }
+                return Ok(tiles);
+            }
+            Event::End(ref e) if e.local_name().as_ref() == b"data" => {
+                buf.clear();
                 return Ok(Vec::new());
+            }
+            Event::Eof => {
+                return Err(Error::PrematureEnd("Ran out of XML data".to_owned()));
             }
             _ => {}
         }
+        buf.clear();
     }
-    Err(Error::PrematureEnd("Ran out of XML data".to_owned()))
 }
 
 fn convert_to_tiles(data: &[u8], tilesets: &[MapTilesetGid]) -> Vec<Option<LayerTileData>> {

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -1,9 +1,8 @@
 use std::{convert::TryInto, io::Read};
 
 use base64::Engine;
-use quick_xml::events::Event;
 
-use crate::{CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
+use crate::{util::read_text_or_cdata, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
 
 pub(crate) fn parse_data_line<R: std::io::BufRead>(
     encoding: Option<String>,
@@ -52,35 +51,7 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
 fn parse_base64<R: std::io::BufRead>(
     elem: &mut crate::util::XmlElement<'_, R>,
 ) -> Result<Vec<u8>> {
-    let mut text = None;
-    loop {
-        match elem
-            .reader
-            .read_event_into(elem.buf)
-            .map_err(Error::XmlDecodingError)?
-        {
-            Event::Text(e) => {
-                text = Some(e.unescape().map_err(Error::XmlDecodingError)?.into_owned());
-                elem.buf.clear();
-            }
-            Event::CData(e) => {
-                text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
-                elem.buf.clear();
-            }
-            Event::End(_) => {
-                elem.buf.clear();
-                break;
-            }
-            Event::Eof => {
-                return Err(Error::PrematureEnd("Ran out of XML data".to_owned()));
-            }
-            _ => {
-                elem.buf.clear();
-            }
-        }
-    }
-
-    let text = match text {
+    let text = match read_text_or_cdata(elem, "Ran out of XML data")? {
         Some(text) => text,
         None => return Ok(Vec::new()),
     };
@@ -107,35 +78,7 @@ fn decode_csv<R: std::io::BufRead>(
     elem: &mut crate::util::XmlElement<'_, R>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
-    let mut text = None;
-    loop {
-        match elem
-            .reader
-            .read_event_into(elem.buf)
-            .map_err(Error::XmlDecodingError)?
-        {
-            Event::Text(e) => {
-                text = Some(e.unescape().map_err(Error::XmlDecodingError)?.into_owned());
-                elem.buf.clear();
-            }
-            Event::CData(e) => {
-                text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
-                elem.buf.clear();
-            }
-            Event::End(_) => {
-                elem.buf.clear();
-                break;
-            }
-            Event::Eof => {
-                return Err(Error::PrematureEnd("Ran out of XML data".to_owned()));
-            }
-            _ => {
-                elem.buf.clear();
-            }
-        }
-    }
-
-    let text = match text {
+    let text = match read_text_or_cdata(elem, "Ran out of XML data")? {
         Some(text) => text,
         None => return Ok(Vec::new()),
     };

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -9,7 +9,7 @@ use crate::{
 pub(crate) fn parse_data_line<R: std::io::BufRead>(
     encoding: Option<String>,
     compression: Option<String>,
-    mut elem: crate::util::XmlElement<'_, R>,
+    elem: crate::util::XmlElement<'_, R>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
     if elem.is_empty {
@@ -27,17 +27,17 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
         };
     }
     match (encoding.as_deref(), compression.as_deref()) {
-        (Some("csv"), None) => decode_csv(&mut elem, tilesets),
+        (Some("csv"), None) => decode_csv(elem, tilesets),
 
-        (Some("base64"), None) => parse_base64(&mut elem).map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("zlib")) => parse_base64(&mut elem)
+        (Some("base64"), None) => parse_base64(elem).map(|v| convert_to_tiles(&v, tilesets)),
+        (Some("base64"), Some("zlib")) => parse_base64(elem)
             .and_then(|data| process_decoder(Ok(flate2::bufread::ZlibDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("gzip")) => parse_base64(&mut elem)
+        (Some("base64"), Some("gzip")) => parse_base64(elem)
             .and_then(|data| process_decoder(Ok(flate2::bufread::GzDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
         #[cfg(feature = "zstd")]
-        (Some("base64"), Some("zstd")) => parse_base64(&mut elem)
+        (Some("base64"), Some("zstd")) => parse_base64(elem)
             .and_then(|data| process_decoder(zstd::stream::read::Decoder::with_buffer(&data[..])))
             .map(|v| convert_to_tiles(&v, tilesets)),
 
@@ -48,7 +48,9 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
     }
 }
 
-fn parse_base64<R: std::io::BufRead>(elem: &mut crate::util::XmlElement<'_, R>) -> Result<Vec<u8>> {
+fn parse_base64<R: std::io::BufRead>(
+    elem: crate::util::XmlElement<'_, R>,
+) -> Result<Vec<u8>> {
     let text = match read_text_or_cdata(elem, "Ran out of XML data")? {
         Some(text) => text,
         None => return Ok(Vec::new()),
@@ -73,7 +75,7 @@ fn process_decoder(decoder: std::io::Result<impl Read>) -> Result<Vec<u8>> {
 }
 
 fn decode_csv<R: std::io::BufRead>(
-    elem: &mut crate::util::XmlElement<'_, R>,
+    elem: crate::util::XmlElement<'_, R>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
     let text = match read_text_or_cdata(elem, "Ran out of XML data")? {

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -12,9 +12,9 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
     elem: crate::util::XmlElement<'_, R>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
-    let text = read_text_or_cdata(elem, "Ran out of XML data")?;
-    let text = text.as_deref().unwrap_or("");
-    match (encoding.as_deref(), compression.as_deref()) {
+    let encoding_ref = encoding.as_deref();
+    let compression_ref = compression.as_deref();
+    read_text_or_cdata(elem, |text| match (encoding_ref, compression_ref) {
         (Some("csv"), None) => decode_csv(text, tilesets),
 
         (Some("base64"), None) => parse_base64(text).map(|v| convert_to_tiles(&v, tilesets)),
@@ -30,10 +30,10 @@ pub(crate) fn parse_data_line<R: std::io::BufRead>(
             .map(|v| convert_to_tiles(&v, tilesets)),
 
         _ => Err(Error::InvalidEncodingFormat {
-            encoding,
-            compression,
+            encoding: encoding.clone(),
+            compression: compression.clone(),
         }),
-    }
+    })
 }
 
 fn parse_base64(text: &str) -> Result<Vec<u8>> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -158,7 +158,7 @@ impl Map {
 
 impl Map {
     pub(crate) fn parse_xml<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         map_path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -184,7 +184,6 @@ impl Map {
             }
             ((colour, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
         );
-        elem.buf.clear();
 
         let infinite = infinite.unwrap_or(false);
         let user_type = user_type.or(user_class);
@@ -198,7 +197,7 @@ impl Map {
         let mut properties = HashMap::new();
         let mut tilesets = Vec::new();
 
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "tileset" => |elem| {
                 let res = Tileset::parse_xml_in_map(elem, map_path, reader, cache)?;
                 match res.result_type {

--- a/src/map.rs
+++ b/src/map.rs
@@ -157,10 +157,8 @@ impl Map {
 }
 
 impl Map {
-    pub(crate) fn parse_xml(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn parse_xml<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         map_path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -169,7 +167,7 @@ impl Map {
             (c, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length),
             (v, o, w, h, tw, th),
         ) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("backgroundcolor") => colour ?= v.parse(),
                 Some("infinite") => infinite = v == "1",
                 Some("type") => user_type ?= v.parse(),
@@ -186,7 +184,7 @@ impl Map {
             }
             ((colour, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
         );
-        buf.clear();
+        elem.buf.clear();
 
         let infinite = infinite.unwrap_or(false);
         let user_type = user_type.or(user_class);
@@ -200,9 +198,9 @@ impl Map {
         let mut properties = HashMap::new();
         let mut tilesets = Vec::new();
 
-        parse_tag!(xml_reader, buf, "map", {
-            "tileset" => |attrs| {
-                let res = Tileset::parse_xml_in_map(xml_reader, buf, attrs, map_path, reader, cache)?;
+        parse_tag!(&mut elem, {
+            "tileset" => |elem| {
+                let res = Tileset::parse_xml_in_map(elem, map_path, reader, cache)?;
                 match res.result_type {
                     EmbeddedParseResultType::ExternalReference { tileset_path } => {
                         let tileset = if let Some(ts) = cache.get_tileset(&tileset_path) {
@@ -221,11 +219,9 @@ impl Map {
                 };
                 Ok(())
             },
-            "layer" => |attrs| {
+            "layer" => |elem| {
                 layers.push(LayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     LayerTag::Tiles,
                     infinite,
                     map_path,
@@ -236,11 +232,9 @@ impl Map {
                 )?);
                 Ok(())
             },
-            "imagelayer" => |attrs| {
+            "imagelayer" => |elem| {
                 layers.push(LayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     LayerTag::Image,
                     infinite,
                     map_path,
@@ -251,11 +245,9 @@ impl Map {
                 )?);
                 Ok(())
             },
-            "objectgroup" => |attrs| {
+            "objectgroup" => |elem| {
                 layers.push(LayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     LayerTag::Objects,
                     infinite,
                     map_path,
@@ -266,11 +258,9 @@ impl Map {
                 )?);
                 Ok(())
             },
-            "group" => |attrs| {
+            "group" => |elem| {
                 layers.push(LayerData::new(
-                    xml_reader,
-                    buf,
-                    attrs,
+                    elem,
                     LayerTag::Group,
                     infinite,
                     map_path,
@@ -281,8 +271,8 @@ impl Map {
                 )?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/map.rs
+++ b/src/map.rs
@@ -8,14 +8,12 @@ use std::{
     sync::Arc,
 };
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::{Error, Result},
+    error::Result,
     layers::{LayerData, LayerTag},
     properties::{parse_properties, Color, Properties},
     tileset::Tileset,
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
     EmbeddedParseResultType, Layer, ResourceCache, ResourceReader,
 };
 
@@ -160,8 +158,9 @@ impl Map {
 
 impl Map {
     pub(crate) fn parse_xml(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         map_path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -178,7 +177,7 @@ impl Map {
                 Some("staggeraxis") => stagger_axis ?= v.parse::<StaggerAxis>(),
                 Some("staggerindex") => stagger_index ?= v.parse::<StaggerIndex>(),
                 Some("hexsidelength") => hex_side_length ?= v.parse(),
-                "version" => version = v,
+                "version" => version = v.to_string(),
                 "orientation" => orientation ?= v.parse::<Orientation>(),
                 "width" => width ?= v.parse::<u32>(),
                 "height" => height ?= v.parse::<u32>(),
@@ -187,6 +186,7 @@ impl Map {
             }
             ((colour, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
         );
+        buf.clear();
 
         let infinite = infinite.unwrap_or(false);
         let user_type = user_type.or(user_class);
@@ -200,9 +200,9 @@ impl Map {
         let mut properties = HashMap::new();
         let mut tilesets = Vec::new();
 
-        parse_tag!(parser, "map", {
-            "tileset" => |attrs: Vec<OwnedAttribute>| {
-                let res = Tileset::parse_xml_in_map(parser, &attrs, map_path,  reader, cache)?;
+        parse_tag!(xml_reader, buf, "map", {
+            "tileset" => |attrs| {
+                let res = Tileset::parse_xml_in_map(xml_reader, buf, attrs, map_path, reader, cache)?;
                 match res.result_type {
                     EmbeddedParseResultType::ExternalReference { tileset_path } => {
                         let tileset = if let Some(ts) = cache.get_tileset(&tileset_path) {
@@ -223,7 +223,8 @@ impl Map {
             },
             "layer" => |attrs| {
                 layers.push(LayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     LayerTag::Tiles,
                     infinite,
@@ -237,7 +238,8 @@ impl Map {
             },
             "imagelayer" => |attrs| {
                 layers.push(LayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     LayerTag::Image,
                     infinite,
@@ -251,7 +253,8 @@ impl Map {
             },
             "objectgroup" => |attrs| {
                 layers.push(LayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     LayerTag::Objects,
                     infinite,
@@ -265,7 +268,8 @@ impl Map {
             },
             "group" => |attrs| {
                 layers.push(LayerData::new(
-                    parser,
+                    xml_reader,
+                    buf,
                     attrs,
                     LayerTag::Group,
                     infinite,
@@ -278,7 +282,7 @@ impl Map {
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
         });

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -4,7 +4,7 @@ use crate::{
     error::{Error, Result},
     properties::{parse_properties, Properties},
     template::Template,
-    util::{get_attrs, map_wrapper, parse_tag},
+    util::{get_attrs, map_wrapper, parse_tag, read_text_or_cdata},
     Color, Gid, MapTilesetGid, ResourceCache, ResourceReader, Tile, TileId, Tileset,
 };
 
@@ -425,15 +425,10 @@ impl ObjectData {
     }
 
     fn new_text<R: std::io::BufRead>(
-        elem: crate::util::XmlElement<'_, R>,
+        mut elem: crate::util::XmlElement<'_, R>,
         width: f32,
         height: f32,
     ) -> Result<ObjectShape> {
-        if elem.is_empty {
-            return Err(Error::InvalidObjectData {
-                description: "Text attribute contained no content".into(),
-            });
-        }
         let (
             font_family,
             pixel_size,
@@ -505,42 +500,11 @@ impl ObjectData {
         let kerning = kerning.map_or(true, |k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
-        let mut contents = None;
-        loop {
-            match elem
-                .reader
-                .read_event_into(elem.buf)
-                .map_err(Error::XmlDecodingError)?
-            {
-                quick_xml::events::Event::Text(e) => {
-                    contents = Some(
-                        e.unescape()
-                            .map_err(Error::XmlDecodingError)?
-                            .into_owned(),
-                    );
-                    elem.buf.clear();
-                }
-                quick_xml::events::Event::CData(e) => {
-                    contents = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
-                    elem.buf.clear();
-                }
-                quick_xml::events::Event::End(_) => {
-                    elem.buf.clear();
-                    break;
-                }
-                quick_xml::events::Event::Eof => {
-                    return Err(Error::PrematureEnd(
-                        "XML stream ended when trying to parse text contents".to_owned(),
-                    ));
-                }
-                _ => {
-                    elem.buf.clear();
-                }
-            }
-        }
-        let contents = contents.ok_or(Error::InvalidObjectData {
-            description: "Text attribute contained no content".into(),
-        })?;
+        let contents = read_text_or_cdata(
+            &mut elem,
+            "XML stream ended when trying to parse text contents",
+        )?
+        .unwrap_or_default();
 
         Ok(ObjectShape::Text {
             font_family,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -218,7 +218,7 @@ impl ObjectData {
     /// If it is known that the object has no tile images in it (i.e. collision data)
     /// then we can pass in [`None`] as the tilesets
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         tilesets: Option<&[MapTilesetGid]>,
         for_tileset: Option<Arc<Tileset>>,
         // Base path is a directory to which all other files are relative to
@@ -243,7 +243,6 @@ impl ObjectData {
             }
             (id, tile, name, user_type, user_class, width, height, visible, rotation, template, x, y)
         );
-        elem.buf.clear();
         let x = x.unwrap_or(0.);
         let y = y.unwrap_or(0.);
         let mut tile = tile.and_then(|bits| {
@@ -296,13 +295,13 @@ impl ObjectData {
         let mut shape = None;
         let mut properties = HashMap::new();
 
-        parse_tag!(&mut elem, {
-            "ellipse" => |mut elem: crate::util::XmlElement<'_, R>| {
+        parse_tag!(elem, {
+            "ellipse" => |elem: crate::util::XmlElement<'_, R>| {
                 shape = Some(ObjectShape::Ellipse {
                     width,
                     height,
                 });
-                parse_tag!(&mut elem, {});
+                parse_tag!(elem, {});
                 Ok(())
             },
             "polyline" => |elem| {
@@ -313,9 +312,9 @@ impl ObjectData {
                 shape = Some(ObjectData::new_polygon(elem)?);
                 Ok(())
             },
-            "point" => |mut elem: crate::util::XmlElement<'_, R>| {
+            "point" => |elem: crate::util::XmlElement<'_, R>| {
                 shape = Some(ObjectShape::Point(x, y));
-                parse_tag!(&mut elem, {});
+                parse_tag!(elem, {});
                 Ok(())
             },
             "text" => |elem| {
@@ -399,7 +398,7 @@ impl ObjectData {
 
 impl ObjectData {
     fn new_polyline<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
     ) -> Result<ObjectShape> {
         let points = get_attrs!(
             for v in (elem.attrs) {
@@ -407,12 +406,12 @@ impl ObjectData {
             }
             points
         );
-        parse_tag!(&mut elem, {});
+        parse_tag!(elem, {});
         Ok(ObjectShape::Polyline { points })
     }
 
     fn new_polygon<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
     ) -> Result<ObjectShape> {
         let points = get_attrs!(
             for v in (elem.attrs) {
@@ -420,12 +419,12 @@ impl ObjectData {
             }
             points
         );
-        parse_tag!(&mut elem, {});
+        parse_tag!(elem, {});
         Ok(ObjectShape::Polygon { points })
     }
 
     fn new_text<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         width: f32,
         height: f32,
     ) -> Result<ObjectShape> {
@@ -483,7 +482,6 @@ impl ObjectData {
                 valign,
             )
         );
-        elem.buf.clear();
         let font_family = font_family.unwrap_or_else(|| "sans-serif".to_string());
         let pixel_size = pixel_size.unwrap_or(16);
         let color = color.unwrap_or(Color {
@@ -501,7 +499,7 @@ impl ObjectData {
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
         let contents = read_text_or_cdata(
-            &mut elem,
+            elem,
             "XML stream ended when trying to parse text contents",
         )?
         .unwrap_or_default();

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,12 +1,10 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     error::{Error, Result},
     properties::{parse_properties, Properties},
     template::Template,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
+    util::{get_attrs, map_wrapper, parse_tag},
     Color, Gid, MapTilesetGid, ResourceCache, ResourceReader, Tile, TileId, Tileset,
 };
 
@@ -220,8 +218,9 @@ impl ObjectData {
     /// If it is known that the object has no tile images in it (i.e. collision data)
     /// then we can pass in [`None`] as the tilesets
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         tilesets: Option<&[MapTilesetGid]>,
         for_tileset: Option<Arc<Tileset>>,
         // Base path is a directory to which all other files are relative to
@@ -246,6 +245,7 @@ impl ObjectData {
             }
             (id, tile, name, user_type, user_class, width, height, visible, rotation, template, x, y)
         );
+        buf.clear();
         let x = x.unwrap_or(0.);
         let y = y.unwrap_or(0.);
         let mut tile = tile.and_then(|bits| {
@@ -298,7 +298,7 @@ impl ObjectData {
         let mut shape = None;
         let mut properties = HashMap::new();
 
-        parse_tag!(parser, "object", {
+        parse_tag!(xml_reader, buf, "object", {
             "ellipse" => |_| {
                 shape = Some(ObjectShape::Ellipse {
                     width,
@@ -319,11 +319,11 @@ impl ObjectData {
                 Ok(())
             },
             "text" => |attrs| {
-                shape = Some(ObjectData::new_text(attrs, parser, width, height)?);
+                shape = Some(ObjectData::new_text(xml_reader, buf, attrs, width, height)?);
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
         });
@@ -398,7 +398,7 @@ impl ObjectData {
 }
 
 impl ObjectData {
-    fn new_polyline(attrs: Vec<OwnedAttribute>) -> Result<ObjectShape> {
+    fn new_polyline(attrs: quick_xml::events::BytesStart<'_>) -> Result<ObjectShape> {
         let points = get_attrs!(
             for v in attrs {
                 "points" => points ?= ObjectData::parse_points(v),
@@ -408,7 +408,7 @@ impl ObjectData {
         Ok(ObjectShape::Polyline { points })
     }
 
-    fn new_polygon(attrs: Vec<OwnedAttribute>) -> Result<ObjectShape> {
+    fn new_polygon(attrs: quick_xml::events::BytesStart<'_>) -> Result<ObjectShape> {
         let points = get_attrs!(
             for v in attrs {
                 "points" => points ?= ObjectData::parse_points(v),
@@ -419,8 +419,9 @@ impl ObjectData {
     }
 
     fn new_text(
-        attrs: Vec<OwnedAttribute>,
-        parser: &mut impl Iterator<Item = XmlEventResult>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         width: f32,
         height: f32,
     ) -> Result<ObjectShape> {
@@ -438,7 +439,7 @@ impl ObjectData {
             valign,
         ) = get_attrs!(
             for v in attrs {
-                Some("fontfamily") => font_family = v,
+                Some("fontfamily") => font_family = v.to_string(),
                 Some("pixelsize") => pixel_size ?= v.parse(),
                 Some("wrap") => wrap ?= v.parse(),
                 Some("color") => color ?= v.parse(),
@@ -447,14 +448,14 @@ impl ObjectData {
                 Some("underline") => underline ?= v.parse(),
                 Some("strikeout") => strikeout ?= v.parse(),
                 Some("kerning") => kerning ?= v.parse::<i32>(),
-                Some("halign") => halign = match v.as_str() {
+                Some("halign") => halign = match v {
                     "left" => HorizontalAlignment::Left,
                     "center" => HorizontalAlignment::Center,
                     "right" => HorizontalAlignment::Right,
                     "justify" => HorizontalAlignment::Justify,
                     _ => return Err(Error::MalformedAttributes("`halign` property did not contain a valid value of 'left', 'center', 'right' or 'justify'".to_string()))
                 },
-                Some("valign") => valign = match v.as_str() {
+                Some("valign") => valign = match v {
                     "top" => VerticalAlignment::Top,
                     "center" => VerticalAlignment::Center,
                     "bottom" => VerticalAlignment::Bottom,
@@ -478,6 +479,7 @@ impl ObjectData {
                 valign,
             )
         );
+        buf.clear();
         let font_family = font_family.unwrap_or_else(|| "sans-serif".to_string());
         let pixel_size = pixel_size.unwrap_or(16);
         let color = color.unwrap_or(Color {
@@ -494,20 +496,35 @@ impl ObjectData {
         let kerning = kerning.map_or(true, |k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
-        let contents = match parser.next().map_or_else(
-            || {
-                Err(Error::PrematureEnd(
-                    "XML stream ended when trying to parse text contents".to_owned(),
-                ))
-            },
-            |r| r.map_err(Error::XmlDecodingError),
-        )? {
-            xml::reader::XmlEvent::Characters(contents) => contents,
-            _ => {
-                return Err(Error::InvalidObjectData {
-                    description: "Text attribute contained anything but characters as content"
-                        .into(),
-                })
+        let contents = loop {
+            match xml_reader
+                .read_event_into(buf)
+                .map_err(Error::XmlDecodingError)?
+            {
+                quick_xml::events::Event::Text(e) => {
+                    let text = e.unescape().map_err(Error::XmlDecodingError)?.into_owned();
+                    buf.clear();
+                    break text;
+                }
+                quick_xml::events::Event::CData(e) => {
+                    let text = String::from_utf8_lossy(e.as_ref()).into_owned();
+                    buf.clear();
+                    break text;
+                }
+                quick_xml::events::Event::End(ref e) if e.local_name().as_ref() == b"text" => {
+                    buf.clear();
+                    return Err(Error::InvalidObjectData {
+                        description: "Text attribute contained no content".into(),
+                    });
+                }
+                quick_xml::events::Event::Eof => {
+                    return Err(Error::PrematureEnd(
+                        "XML stream ended when trying to parse text contents".to_owned(),
+                    ));
+                }
+                _ => {
+                    buf.clear();
+                }
             }
         };
 
@@ -529,7 +546,7 @@ impl ObjectData {
         })
     }
 
-    fn parse_points(s: String) -> Result<Vec<(f32, f32)>> {
+    fn parse_points(s: &str) -> Result<Vec<(f32, f32)>> {
         let pairs = s.split(' ');
         pairs
             .map(|point| point.split(','))

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -217,10 +217,8 @@ impl ObjectData {
 impl ObjectData {
     /// If it is known that the object has no tile images in it (i.e. collision data)
     /// then we can pass in [`None`] as the tilesets
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         tilesets: Option<&[MapTilesetGid]>,
         for_tileset: Option<Arc<Tileset>>,
         // Base path is a directory to which all other files are relative to
@@ -229,7 +227,7 @@ impl ObjectData {
         cache: &mut impl ResourceCache,
     ) -> Result<ObjectData> {
         let (id, tile, mut n, mut t, c, mut w, mut h, mut v, mut r, template, x, y) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("id") => id ?= v.parse(),
                 Some("gid") => tile ?= v.parse::<u32>(),
                 Some("name") => name ?= v.parse(),
@@ -245,7 +243,7 @@ impl ObjectData {
             }
             (id, tile, name, user_type, user_class, width, height, visible, rotation, template, x, y)
         );
-        buf.clear();
+        elem.buf.clear();
         let x = x.unwrap_or(0.);
         let y = y.unwrap_or(0.);
         let mut tile = tile.and_then(|bits| {
@@ -298,32 +296,34 @@ impl ObjectData {
         let mut shape = None;
         let mut properties = HashMap::new();
 
-        parse_tag!(xml_reader, buf, "object", {
-            "ellipse" => |_| {
+        parse_tag!(&mut elem, {
+            "ellipse" => |mut elem: crate::util::XmlElement<'_, R>| {
                 shape = Some(ObjectShape::Ellipse {
                     width,
                     height,
                 });
+                parse_tag!(&mut elem, {});
                 Ok(())
             },
-            "polyline" => |attrs| {
-                shape = Some(ObjectData::new_polyline(attrs)?);
+            "polyline" => |elem| {
+                shape = Some(ObjectData::new_polyline(elem)?);
                 Ok(())
             },
-            "polygon" => |attrs| {
-                shape = Some(ObjectData::new_polygon(attrs)?);
+            "polygon" => |elem| {
+                shape = Some(ObjectData::new_polygon(elem)?);
                 Ok(())
             },
-            "point" => |_| {
+            "point" => |mut elem: crate::util::XmlElement<'_, R>| {
                 shape = Some(ObjectShape::Point(x, y));
+                parse_tag!(&mut elem, {});
                 Ok(())
             },
-            "text" => |attrs| {
-                shape = Some(ObjectData::new_text(xml_reader, buf, attrs, width, height)?);
+            "text" => |elem| {
+                shape = Some(ObjectData::new_text(elem, width, height)?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });
@@ -398,33 +398,42 @@ impl ObjectData {
 }
 
 impl ObjectData {
-    fn new_polyline(attrs: quick_xml::events::BytesStart<'_>) -> Result<ObjectShape> {
+    fn new_polyline<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
+    ) -> Result<ObjectShape> {
         let points = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "points" => points ?= ObjectData::parse_points(v),
             }
             points
         );
+        parse_tag!(&mut elem, {});
         Ok(ObjectShape::Polyline { points })
     }
 
-    fn new_polygon(attrs: quick_xml::events::BytesStart<'_>) -> Result<ObjectShape> {
+    fn new_polygon<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
+    ) -> Result<ObjectShape> {
         let points = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "points" => points ?= ObjectData::parse_points(v),
             }
             points
         );
+        parse_tag!(&mut elem, {});
         Ok(ObjectShape::Polygon { points })
     }
 
-    fn new_text(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    fn new_text<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         width: f32,
         height: f32,
     ) -> Result<ObjectShape> {
+        if elem.is_empty {
+            return Err(Error::InvalidObjectData {
+                description: "Text attribute contained no content".into(),
+            });
+        }
         let (
             font_family,
             pixel_size,
@@ -438,7 +447,7 @@ impl ObjectData {
             halign,
             valign,
         ) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("fontfamily") => font_family = v.to_string(),
                 Some("pixelsize") => pixel_size ?= v.parse(),
                 Some("wrap") => wrap ?= v.parse(),
@@ -479,7 +488,7 @@ impl ObjectData {
                 valign,
             )
         );
-        buf.clear();
+        elem.buf.clear();
         let font_family = font_family.unwrap_or_else(|| "sans-serif".to_string());
         let pixel_size = pixel_size.unwrap_or(16);
         let color = color.unwrap_or(Color {
@@ -496,26 +505,28 @@ impl ObjectData {
         let kerning = kerning.map_or(true, |k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
-        let contents = loop {
-            match xml_reader
-                .read_event_into(buf)
+        let mut contents = None;
+        loop {
+            match elem
+                .reader
+                .read_event_into(elem.buf)
                 .map_err(Error::XmlDecodingError)?
             {
                 quick_xml::events::Event::Text(e) => {
-                    let text = e.unescape().map_err(Error::XmlDecodingError)?.into_owned();
-                    buf.clear();
-                    break text;
+                    contents = Some(
+                        e.unescape()
+                            .map_err(Error::XmlDecodingError)?
+                            .into_owned(),
+                    );
+                    elem.buf.clear();
                 }
                 quick_xml::events::Event::CData(e) => {
-                    let text = String::from_utf8_lossy(e.as_ref()).into_owned();
-                    buf.clear();
-                    break text;
+                    contents = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
+                    elem.buf.clear();
                 }
-                quick_xml::events::Event::End(ref e) if e.local_name().as_ref() == b"text" => {
-                    buf.clear();
-                    return Err(Error::InvalidObjectData {
-                        description: "Text attribute contained no content".into(),
-                    });
+                quick_xml::events::Event::End(_) => {
+                    elem.buf.clear();
+                    break;
                 }
                 quick_xml::events::Event::Eof => {
                     return Err(Error::PrematureEnd(
@@ -523,10 +534,13 @@ impl ObjectData {
                     ));
                 }
                 _ => {
-                    buf.clear();
+                    elem.buf.clear();
                 }
             }
-        };
+        }
+        let contents = contents.ok_or(Error::InvalidObjectData {
+            description: "Text attribute contained no content".into(),
+        })?;
 
         Ok(ObjectShape::Text {
             font_family,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -498,9 +498,7 @@ impl ObjectData {
         let kerning = kerning.map_or(true, |k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
-        let contents =
-            read_text_or_cdata(elem, "XML stream ended when trying to parse text contents")?
-                .unwrap_or_default();
+        let contents = read_text_or_cdata(elem, |text| Ok(text.to_string()))?;
 
         Ok(ObjectShape::Text {
             font_family,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -498,11 +498,9 @@ impl ObjectData {
         let kerning = kerning.map_or(true, |k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
-        let contents = read_text_or_cdata(
-            elem,
-            "XML stream ended when trying to parse text contents",
-        )?
-        .unwrap_or_default();
+        let contents =
+            read_text_or_cdata(elem, "XML stream ended when trying to parse text contents")?
+                .unwrap_or_default();
 
         Ok(ObjectShape::Text {
             font_family,

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -26,11 +26,11 @@ pub fn parse_map(
             .map_err(Error::XmlDecodingError)?
         {
             Event::Start(e) if e.local_name().as_ref() == b"map" => {
-                let elem = XmlElement::new(&mut parser, &mut buf, e.into_owned(), false);
+                let elem = XmlElement::new(&mut parser, &mut buf, e, false);
                 return Map::parse_xml(elem, path, reader, cache);
             }
             Event::Empty(e) if e.local_name().as_ref() == b"map" => {
-                let elem = XmlElement::new(&mut parser, &mut buf, e.into_owned(), true);
+                let elem = XmlElement::new(&mut parser, &mut buf, e, true);
                 return Map::parse_xml(elem, path, reader, cache);
             }
             Event::Eof => {

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 
-use crate::{Error, Map, ResourceCache, ResourceReader, Result};
+use crate::{util::XmlElement, Error, Map, ResourceCache, ResourceReader, Result};
 
 pub fn parse_map(
     path: &Path,
@@ -18,7 +18,6 @@ pub fn parse_map(
             err: Box::new(err),
         })?;
     let mut parser = Reader::from_reader(BufReader::new(file));
-    parser.expand_empty_elements(true);
     let mut buf = Vec::new();
     let mut event_buf = Vec::new();
     loop {
@@ -27,14 +26,12 @@ pub fn parse_map(
             .map_err(Error::XmlDecodingError)?
         {
             Event::Start(e) if e.local_name().as_ref() == b"map" => {
-                return Map::parse_xml(
-                    &mut parser,
-                    &mut buf,
-                    e.into_owned(),
-                    path,
-                    reader,
-                    cache,
-                );
+                let elem = XmlElement::new(&mut parser, &mut buf, e.into_owned(), false);
+                return Map::parse_xml(elem, path, reader, cache);
+            }
+            Event::Empty(e) if e.local_name().as_ref() == b"map" => {
+                let elem = XmlElement::new(&mut parser, &mut buf, e.into_owned(), true);
+                return Map::parse_xml(elem, path, reader, cache);
             }
             Event::Eof => {
                 return Err(Error::PrematureEnd(

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -20,7 +20,6 @@ pub fn parse_map(
     parse_root_element(
         &mut parser,
         b"map",
-        "Document ended before map was parsed",
         |elem| Map::parse_xml(elem, path, reader, cache),
     )
 }

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -17,9 +17,7 @@ pub fn parse_map(
             err: Box::new(err),
         })?;
     let mut parser = Reader::from_reader(BufReader::new(file));
-    parse_root_element(
-        &mut parser,
-        b"map",
-        |elem| Map::parse_xml(elem, path, reader, cache),
-    )
+    parse_root_element(&mut parser, b"map", |elem| {
+        Map::parse_xml(elem, path, reader, cache)
+    })
 }

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -17,10 +17,8 @@ pub fn parse_map(
             err: Box::new(err),
         })?;
     let mut parser = Reader::from_reader(BufReader::new(file));
-    let mut buf = Vec::new();
     parse_root_element(
         &mut parser,
-        &mut buf,
         b"map",
         "Document ended before map was parsed",
         |elem| Map::parse_xml(elem, path, reader, cache),

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -1,6 +1,8 @@
+use std::io::BufReader;
 use std::path::Path;
 
-use xml::{reader::XmlEvent, EventReader};
+use quick_xml::events::Event;
+use quick_xml::Reader;
 
 use crate::{Error, Map, ResourceCache, ResourceReader, Result};
 
@@ -9,36 +11,38 @@ pub fn parse_map(
     reader: &mut impl ResourceReader,
     cache: &mut impl ResourceCache,
 ) -> Result<Map> {
-    let mut parser =
-        EventReader::new(
-            reader
-                .read_from(path)
-                .map_err(|err| Error::ResourceLoadingError {
-                    path: path.to_owned(),
-                    err: Box::new(err),
-                })?,
-        );
+    let file = reader
+        .read_from(path)
+        .map_err(|err| Error::ResourceLoadingError {
+            path: path.to_owned(),
+            err: Box::new(err),
+        })?;
+    let mut parser = Reader::from_reader(BufReader::new(file));
+    parser.expand_empty_elements(true);
+    let mut buf = Vec::new();
+    let mut event_buf = Vec::new();
     loop {
-        match parser.next().map_err(Error::XmlDecodingError)? {
-            XmlEvent::StartElement {
-                name, attributes, ..
-            } => {
-                if name.local_name == "map" {
-                    return Map::parse_xml(
-                        &mut parser.into_iter(),
-                        attributes,
-                        path,
-                        reader,
-                        cache,
-                    );
-                }
+        match parser
+            .read_event_into(&mut event_buf)
+            .map_err(Error::XmlDecodingError)?
+        {
+            Event::Start(e) if e.local_name().as_ref() == b"map" => {
+                return Map::parse_xml(
+                    &mut parser,
+                    &mut buf,
+                    e.into_owned(),
+                    path,
+                    reader,
+                    cache,
+                );
             }
-            XmlEvent::EndDocument => {
+            Event::Eof => {
                 return Err(Error::PrematureEnd(
                     "Document ended before map was parsed".to_string(),
                 ))
             }
             _ => {}
         }
+        event_buf.clear();
     }
 }

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -1,10 +1,9 @@
 use std::io::BufReader;
 use std::path::Path;
 
-use quick_xml::events::Event;
 use quick_xml::Reader;
 
-use crate::{util::XmlElement, Error, Map, ResourceCache, ResourceReader, Result};
+use crate::{util::parse_root_element, Error, Map, ResourceCache, ResourceReader, Result};
 
 pub fn parse_map(
     path: &Path,
@@ -19,27 +18,11 @@ pub fn parse_map(
         })?;
     let mut parser = Reader::from_reader(BufReader::new(file));
     let mut buf = Vec::new();
-    let mut event_buf = Vec::new();
-    loop {
-        match parser
-            .read_event_into(&mut event_buf)
-            .map_err(Error::XmlDecodingError)?
-        {
-            Event::Start(e) if e.local_name().as_ref() == b"map" => {
-                let elem = XmlElement::new(&mut parser, &mut buf, e, false);
-                return Map::parse_xml(elem, path, reader, cache);
-            }
-            Event::Empty(e) if e.local_name().as_ref() == b"map" => {
-                let elem = XmlElement::new(&mut parser, &mut buf, e, true);
-                return Map::parse_xml(elem, path, reader, cache);
-            }
-            Event::Eof => {
-                return Err(Error::PrematureEnd(
-                    "Document ended before map was parsed".to_string(),
-                ))
-            }
-            _ => {}
-        }
-        event_buf.clear();
-    }
+    parse_root_element(
+        &mut parser,
+        &mut buf,
+        b"map",
+        "Document ended before map was parsed",
+        |elem| Map::parse_xml(elem, path, reader, cache),
+    )
 }

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -1,6 +1,8 @@
+use std::io::BufReader;
 use std::path::Path;
 
-use xml::{reader::XmlEvent, EventReader};
+use quick_xml::events::Event;
+use quick_xml::Reader;
 
 use crate::{Error, ResourceCache, ResourceReader, Result, Tileset};
 
@@ -9,34 +11,38 @@ pub fn parse_tileset(
     reader: &mut impl ResourceReader,
     cache: &mut impl ResourceCache,
 ) -> Result<Tileset> {
-    let mut tileset_parser =
-        EventReader::new(
-            reader
-                .read_from(path)
-                .map_err(|err| Error::ResourceLoadingError {
-                    path: path.to_owned(),
-                    err: Box::new(err),
-                })?,
-        );
+    let file = reader
+        .read_from(path)
+        .map_err(|err| Error::ResourceLoadingError {
+            path: path.to_owned(),
+            err: Box::new(err),
+        })?;
+    let mut tileset_parser = Reader::from_reader(BufReader::new(file));
+    tileset_parser.expand_empty_elements(true);
+    let mut buf = Vec::new();
+    let mut event_buf = Vec::new();
     loop {
-        match tileset_parser.next().map_err(Error::XmlDecodingError)? {
-            XmlEvent::StartElement {
-                name, attributes, ..
-            } if name.local_name == "tileset" => {
+        match tileset_parser
+            .read_event_into(&mut event_buf)
+            .map_err(Error::XmlDecodingError)?
+        {
+            Event::Start(e) if e.local_name().as_ref() == b"tileset" => {
                 return Tileset::parse_external_tileset(
-                    &mut tileset_parser.into_iter(),
-                    &attributes,
+                    &mut tileset_parser,
+                    &mut buf,
+                    e.into_owned(),
                     path,
                     reader,
                     cache,
                 );
             }
-            XmlEvent::EndDocument => {
+            Event::Eof => {
                 return Err(Error::PrematureEnd(
                     "Tileset Document ended before map was parsed".to_string(),
                 ))
             }
             _ => {}
         }
+        event_buf.clear();
     }
 }

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -17,10 +17,8 @@ pub fn parse_tileset(
             err: Box::new(err),
         })?;
     let mut tileset_parser = Reader::from_reader(BufReader::new(file));
-    let mut buf = Vec::new();
     parse_root_element(
         &mut tileset_parser,
-        &mut buf,
         b"tileset",
         "Tileset Document ended before map was parsed",
         |elem| Tileset::parse_external_tileset(elem, path, reader, cache),

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -17,9 +17,7 @@ pub fn parse_tileset(
             err: Box::new(err),
         })?;
     let mut tileset_parser = Reader::from_reader(BufReader::new(file));
-    parse_root_element(
-        &mut tileset_parser,
-        b"tileset",
-        |elem| Tileset::parse_external_tileset(elem, path, reader, cache),
-    )
+    parse_root_element(&mut tileset_parser, b"tileset", |elem| {
+        Tileset::parse_external_tileset(elem, path, reader, cache)
+    })
 }

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -26,11 +26,11 @@ pub fn parse_tileset(
             .map_err(Error::XmlDecodingError)?
         {
             Event::Start(e) if e.local_name().as_ref() == b"tileset" => {
-                let elem = XmlElement::new(&mut tileset_parser, &mut buf, e.into_owned(), false);
+                let elem = XmlElement::new(&mut tileset_parser, &mut buf, e, false);
                 return Tileset::parse_external_tileset(elem, path, reader, cache);
             }
             Event::Empty(e) if e.local_name().as_ref() == b"tileset" => {
-                let elem = XmlElement::new(&mut tileset_parser, &mut buf, e.into_owned(), true);
+                let elem = XmlElement::new(&mut tileset_parser, &mut buf, e, true);
                 return Tileset::parse_external_tileset(elem, path, reader, cache);
             }
             Event::Eof => {

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 
-use crate::{Error, ResourceCache, ResourceReader, Result, Tileset};
+use crate::{util::XmlElement, Error, ResourceCache, ResourceReader, Result, Tileset};
 
 pub fn parse_tileset(
     path: &Path,
@@ -18,7 +18,6 @@ pub fn parse_tileset(
             err: Box::new(err),
         })?;
     let mut tileset_parser = Reader::from_reader(BufReader::new(file));
-    tileset_parser.expand_empty_elements(true);
     let mut buf = Vec::new();
     let mut event_buf = Vec::new();
     loop {
@@ -27,14 +26,12 @@ pub fn parse_tileset(
             .map_err(Error::XmlDecodingError)?
         {
             Event::Start(e) if e.local_name().as_ref() == b"tileset" => {
-                return Tileset::parse_external_tileset(
-                    &mut tileset_parser,
-                    &mut buf,
-                    e.into_owned(),
-                    path,
-                    reader,
-                    cache,
-                );
+                let elem = XmlElement::new(&mut tileset_parser, &mut buf, e.into_owned(), false);
+                return Tileset::parse_external_tileset(elem, path, reader, cache);
+            }
+            Event::Empty(e) if e.local_name().as_ref() == b"tileset" => {
+                let elem = XmlElement::new(&mut tileset_parser, &mut buf, e.into_owned(), true);
+                return Tileset::parse_external_tileset(elem, path, reader, cache);
             }
             Event::Eof => {
                 return Err(Error::PrematureEnd(

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -20,7 +20,6 @@ pub fn parse_tileset(
     parse_root_element(
         &mut tileset_parser,
         b"tileset",
-        "Tileset Document ended before map was parsed",
         |elem| Tileset::parse_external_tileset(elem, path, reader, cache),
     )
 }

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -1,10 +1,9 @@
 use std::io::BufReader;
 use std::path::Path;
 
-use quick_xml::events::Event;
 use quick_xml::Reader;
 
-use crate::{util::XmlElement, Error, ResourceCache, ResourceReader, Result, Tileset};
+use crate::{util::parse_root_element, Error, ResourceCache, ResourceReader, Result, Tileset};
 
 pub fn parse_tileset(
     path: &Path,
@@ -19,27 +18,11 @@ pub fn parse_tileset(
         })?;
     let mut tileset_parser = Reader::from_reader(BufReader::new(file));
     let mut buf = Vec::new();
-    let mut event_buf = Vec::new();
-    loop {
-        match tileset_parser
-            .read_event_into(&mut event_buf)
-            .map_err(Error::XmlDecodingError)?
-        {
-            Event::Start(e) if e.local_name().as_ref() == b"tileset" => {
-                let elem = XmlElement::new(&mut tileset_parser, &mut buf, e, false);
-                return Tileset::parse_external_tileset(elem, path, reader, cache);
-            }
-            Event::Empty(e) if e.local_name().as_ref() == b"tileset" => {
-                let elem = XmlElement::new(&mut tileset_parser, &mut buf, e, true);
-                return Tileset::parse_external_tileset(elem, path, reader, cache);
-            }
-            Event::Eof => {
-                return Err(Error::PrematureEnd(
-                    "Tileset Document ended before map was parsed".to_string(),
-                ))
-            }
-            _ => {}
-        }
-        event_buf.clear();
-    }
+    parse_root_element(
+        &mut tileset_parser,
+        &mut buf,
+        b"tileset",
+        "Tileset Document ended before map was parsed",
+        |elem| Tileset::parse_external_tileset(elem, path, reader, cache),
+    )
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -173,12 +173,10 @@ pub(crate) fn parse_properties<R: std::io::BufRead>(
                 }
                 None => {
                     // if the "value" attribute was missing, might be a multiline string
-                    let text = read_text_or_cdata(
+                    read_text_or_cdata(
                         elem,
-                        "XML stream ended when parsing property contents",
+                        |text| Ok(text.to_string()),
                     )?
-                    .unwrap_or_default();
-                    text
                 }
             };
             p.insert(k, PropertyValue::new(t, v)?);

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -136,12 +136,11 @@ impl PropertyValue {
 pub type Properties = HashMap<String, PropertyValue>;
 
 pub(crate) fn parse_properties<R: std::io::BufRead>(
-    mut elem: crate::util::XmlElement<'_, R>,
+    elem: crate::util::XmlElement<'_, R>,
 ) -> Result<Properties> {
     let mut p = HashMap::new();
-    elem.buf.clear();
-    parse_tag!(&mut elem, {
-        "property" => |mut elem: crate::util::XmlElement<'_, R>| {
+    parse_tag!(elem, {
+        "property" => |elem: crate::util::XmlElement<'_, R>| {
             let (t, v_attr, k, p_t) = get_attrs!(
                 for attr in (elem.attrs) {
                     Some("type") => obj_type = attr.to_string(),
@@ -151,11 +150,10 @@ pub(crate) fn parse_properties<R: std::io::BufRead>(
                 }
                 (obj_type, value, name, propertytype)
             );
-            elem.buf.clear();
             let t = t.unwrap_or_else(|| "string".to_owned());
             if t == "class" {
                 let mut properties = HashMap::new();
-                parse_tag!(&mut elem, {
+                parse_tag!(elem, {
                     "properties" => |elem| {
                         properties = parse_properties(elem)?;
                         Ok(())
@@ -170,13 +168,13 @@ pub(crate) fn parse_properties<R: std::io::BufRead>(
 
             let v: String = match v_attr {
                 Some(val) => {
-                    parse_tag!(&mut elem, {});
+                    parse_tag!(elem, {});
                     val
                 }
                 None => {
                     // if the "value" attribute was missing, might be a multiline string
                     let text = read_text_or_cdata(
-                        &mut elem,
+                        elem,
                         "XML stream ended when parsing property contents",
                     )?
                     .unwrap_or_default();

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -137,16 +137,15 @@ impl PropertyValue {
 /// A custom property container.
 pub type Properties = HashMap<String, PropertyValue>;
 
-pub(crate) fn parse_properties(
-    xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-    buf: &mut Vec<u8>,
+pub(crate) fn parse_properties<R: std::io::BufRead>(
+    mut elem: crate::util::XmlElement<'_, R>,
 ) -> Result<Properties> {
     let mut p = HashMap::new();
-    buf.clear();
-    parse_tag!(xml_reader, buf, "properties", {
-        "property" => |attrs: quick_xml::events::BytesStart<'_>| {
+    elem.buf.clear();
+    parse_tag!(&mut elem, {
+        "property" => |mut elem: crate::util::XmlElement<'_, R>| {
             let (t, v_attr, k, p_t) = get_attrs!(
-                for attr in attrs {
+                for attr in (elem.attrs) {
                     Some("type") => obj_type = attr.to_string(),
                     Some("value") => value = attr.to_string(),
                     Some("propertytype") => propertytype = attr.to_string(),
@@ -154,13 +153,13 @@ pub(crate) fn parse_properties(
                 }
                 (obj_type, value, name, propertytype)
             );
-            buf.clear();
+            elem.buf.clear();
             let t = t.unwrap_or_else(|| "string".to_owned());
             if t == "class" {
                 let mut properties = HashMap::new();
-                parse_tag!(xml_reader, buf, "property", {
-                    "properties" => |_| {
-                        properties = parse_properties(xml_reader, buf)?;
+                parse_tag!(&mut elem, {
+                    "properties" => |elem| {
+                        properties = parse_properties(elem)?;
                         Ok(())
                     },
                 });
@@ -171,31 +170,46 @@ pub(crate) fn parse_properties(
                 return Ok(());
             }
 
+            let mut consumed_end = false;
             let v: String = match v_attr {
                 Some(val) => val,
                 None => {
+                    if elem.is_empty {
+                        return Err(Error::MalformedAttributes(format!(
+                            "property '{}' is missing a value",
+                            k
+                        )));
+                    }
                     // if the "value" attribute was missing, might be a multiline string
+                    let mut text = None;
                     loop {
-                        match xml_reader
-                            .read_event_into(buf)
+                        match elem
+                            .reader
+                            .read_event_into(elem.buf)
                             .map_err(Error::XmlDecodingError)?
                         {
                             Event::Text(e) => {
-                                let text = e.unescape().map_err(Error::XmlDecodingError)?.into_owned();
-                                buf.clear();
-                                break text;
+                                text = Some(
+                                    e.unescape()
+                                        .map_err(Error::XmlDecodingError)?
+                                        .into_owned(),
+                                );
+                                elem.buf.clear();
                             }
                             Event::CData(e) => {
-                                let text = String::from_utf8_lossy(e.as_ref()).into_owned();
-                                buf.clear();
-                                break text;
+                                text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
+                                elem.buf.clear();
                             }
-                            Event::End(ref e) if e.local_name().as_ref() == b"property" => {
-                                buf.clear();
-                                return Err(Error::MalformedAttributes(format!(
-                                    "property '{}' is missing a value",
-                                    k
-                                )));
+                            Event::End(_) => {
+                                elem.buf.clear();
+                                consumed_end = true;
+                                let text = text.ok_or_else(|| {
+                                    Error::MalformedAttributes(format!(
+                                        "property '{}' is missing a value",
+                                        k
+                                    ))
+                                })?;
+                                break text;
                             }
                             Event::Eof => {
                                 return Err(Error::PrematureEnd(
@@ -203,13 +217,16 @@ pub(crate) fn parse_properties(
                                 ));
                             }
                             _ => {
-                                buf.clear();
+                                elem.buf.clear();
                             }
                         }
                     }
                 }
             };
 
+            if !consumed_end {
+                parse_tag!(&mut elem, {});
+            }
             p.insert(k, PropertyValue::new(t, v)?);
             Ok(())
         },

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, str::FromStr};
 
-use xml::{attribute::OwnedAttribute, reader::XmlEvent};
+use quick_xml::events::Event;
 
 use crate::{
     error::{Error, Result},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
 };
 
 /// Represents a RGBA color with 8-bit depth on each channel.
@@ -138,30 +138,32 @@ impl PropertyValue {
 pub type Properties = HashMap<String, PropertyValue>;
 
 pub(crate) fn parse_properties(
-    parser: &mut impl Iterator<Item = XmlEventResult>,
+    xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+    buf: &mut Vec<u8>,
 ) -> Result<Properties> {
     let mut p = HashMap::new();
-    parse_tag!(parser, "properties", {
-        "property" => |attrs:Vec<OwnedAttribute>| {
+    buf.clear();
+    parse_tag!(xml_reader, buf, "properties", {
+        "property" => |attrs: quick_xml::events::BytesStart<'_>| {
             let (t, v_attr, k, p_t) = get_attrs!(
                 for attr in attrs {
-                    Some("type") => obj_type = attr,
-                    Some("value") => value = attr,
-                    Some("propertytype") => propertytype = attr,
-                    "name" => name = attr
+                    Some("type") => obj_type = attr.to_string(),
+                    Some("value") => value = attr.to_string(),
+                    Some("propertytype") => propertytype = attr.to_string(),
+                    "name" => name = attr.to_string()
                 }
                 (obj_type, value, name, propertytype)
             );
+            buf.clear();
             let t = t.unwrap_or_else(|| "string".to_owned());
             if t == "class" {
-                // Class properties will have their member values stored in a nested <properties>
-                // element. Only the actually set members are saved. When no members have been set
-                // the properties element is left out entirely.
-                let properties = if has_properties_tag_next(parser) {
-                    parse_properties(parser)?
-                } else {
-                    HashMap::new()
-                };
+                let mut properties = HashMap::new();
+                parse_tag!(xml_reader, buf, "property", {
+                    "properties" => |_| {
+                        properties = parse_properties(xml_reader, buf)?;
+                        Ok(())
+                    },
+                });
                 p.insert(k, PropertyValue::ClassValue {
                     property_type: p_t.unwrap_or_default(),
                     properties,
@@ -173,12 +175,38 @@ pub(crate) fn parse_properties(
                 Some(val) => val,
                 None => {
                     // if the "value" attribute was missing, might be a multiline string
-                    match parser.next() {
-                        Some(Ok(XmlEvent::Characters(s))) => Ok(s),
-                        Some(Err(err)) => Err(Error::XmlDecodingError(err)),
-                        None => unreachable!(), // EndDocument or error must come first
-                        _ => Err(Error::MalformedAttributes(format!("property '{}' is missing a value", k))),
-                    }?
+                    loop {
+                        match xml_reader
+                            .read_event_into(buf)
+                            .map_err(Error::XmlDecodingError)?
+                        {
+                            Event::Text(e) => {
+                                let text = e.unescape().map_err(Error::XmlDecodingError)?.into_owned();
+                                buf.clear();
+                                break text;
+                            }
+                            Event::CData(e) => {
+                                let text = String::from_utf8_lossy(e.as_ref()).into_owned();
+                                buf.clear();
+                                break text;
+                            }
+                            Event::End(ref e) if e.local_name().as_ref() == b"property" => {
+                                buf.clear();
+                                return Err(Error::MalformedAttributes(format!(
+                                    "property '{}' is missing a value",
+                                    k
+                                )));
+                            }
+                            Event::Eof => {
+                                return Err(Error::PrematureEnd(
+                                    "XML stream ended when parsing property contents".to_owned(),
+                                ));
+                            }
+                            _ => {
+                                buf.clear();
+                            }
+                        }
+                    }
                 }
             };
 
@@ -187,27 +215,4 @@ pub(crate) fn parse_properties(
         },
     });
     Ok(p)
-}
-
-/// Checks if there is a properties tag next in the parser. Will consume any whitespace or comments.
-fn has_properties_tag_next(parser: &mut impl Iterator<Item = XmlEventResult>) -> bool {
-    let mut peekable = parser.by_ref().peekable();
-    while let Some(Ok(next)) = peekable.peek() {
-        match next {
-            XmlEvent::StartElement { name, .. } if name.local_name == "properties" => return true,
-            // Ignore whitespace and comments
-            XmlEvent::Whitespace(_) => {
-                peekable.next();
-            }
-            XmlEvent::Comment(_) => {
-                peekable.next();
-            }
-            // If we encounter anything else than whitespace, comments or the properties tag, we
-            // assume there are no properties.
-            _ => {
-                return false;
-            }
-        }
-    }
-    false
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,10 +1,8 @@
 use std::{collections::HashMap, str::FromStr};
 
-use quick_xml::events::Event;
-
 use crate::{
     error::{Error, Result},
-    util::{get_attrs, parse_tag},
+    util::{get_attrs, parse_tag, read_text_or_cdata},
 };
 
 /// Represents a RGBA color with 8-bit depth on each channel.
@@ -170,63 +168,21 @@ pub(crate) fn parse_properties<R: std::io::BufRead>(
                 return Ok(());
             }
 
-            let mut consumed_end = false;
             let v: String = match v_attr {
-                Some(val) => val,
+                Some(val) => {
+                    parse_tag!(&mut elem, {});
+                    val
+                }
                 None => {
-                    if elem.is_empty {
-                        return Err(Error::MalformedAttributes(format!(
-                            "property '{}' is missing a value",
-                            k
-                        )));
-                    }
                     // if the "value" attribute was missing, might be a multiline string
-                    let mut text = None;
-                    loop {
-                        match elem
-                            .reader
-                            .read_event_into(elem.buf)
-                            .map_err(Error::XmlDecodingError)?
-                        {
-                            Event::Text(e) => {
-                                text = Some(
-                                    e.unescape()
-                                        .map_err(Error::XmlDecodingError)?
-                                        .into_owned(),
-                                );
-                                elem.buf.clear();
-                            }
-                            Event::CData(e) => {
-                                text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
-                                elem.buf.clear();
-                            }
-                            Event::End(_) => {
-                                elem.buf.clear();
-                                consumed_end = true;
-                                let text = text.ok_or_else(|| {
-                                    Error::MalformedAttributes(format!(
-                                        "property '{}' is missing a value",
-                                        k
-                                    ))
-                                })?;
-                                break text;
-                            }
-                            Event::Eof => {
-                                return Err(Error::PrematureEnd(
-                                    "XML stream ended when parsing property contents".to_owned(),
-                                ));
-                            }
-                            _ => {
-                                elem.buf.clear();
-                            }
-                        }
-                    }
+                    let text = read_text_or_cdata(
+                        &mut elem,
+                        "XML stream ended when parsing property contents",
+                    )?
+                    .unwrap_or_default();
+                    text
                 }
             };
-
-            if !consumed_end {
-                parse_tag!(&mut elem, {});
-            }
             p.insert(k, PropertyValue::new(t, v)?);
             Ok(())
         },

--- a/src/template.rs
+++ b/src/template.rs
@@ -7,8 +7,8 @@ use quick_xml::Reader;
 
 use crate::{
     util::{parse_tag, XmlElement},
-    EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache,
-    ResourceReader, Result, Tileset,
+    EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache, ResourceReader,
+    Result, Tileset,
 };
 
 /// A template, consisting of an object and a tileset
@@ -50,19 +50,15 @@ impl Template {
                 Event::Start(ref e) if e.local_name().as_ref() == b"template" => {
                     let owned = e.to_owned();
                     event_buf.clear();
-                    let elem =
-                        XmlElement::new(&mut template_parser, &mut buf, owned, false);
-                    let template =
-                        Self::parse_external_template(elem, path, reader, cache)?;
+                    let elem = XmlElement::new(&mut template_parser, &mut buf, owned, false);
+                    let template = Self::parse_external_template(elem, path, reader, cache)?;
                     return Ok(template);
                 }
                 Event::Empty(ref e) if e.local_name().as_ref() == b"template" => {
                     let owned = e.to_owned();
                     event_buf.clear();
-                    let elem =
-                        XmlElement::new(&mut template_parser, &mut buf, owned, true);
-                    let template =
-                        Self::parse_external_template(elem, path, reader, cache)?;
+                    let elem = XmlElement::new(&mut template_parser, &mut buf, owned, true);
+                    let template = Self::parse_external_template(elem, path, reader, cache)?;
                     return Ok(template);
                 }
                 Event::Eof => {

--- a/src/template.rs
+++ b/src/template.rs
@@ -6,7 +6,7 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 
 use crate::{
-    util::parse_tag,
+    util::{parse_tag, XmlElement},
     EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache,
     ResourceReader, Result, Tileset,
 };
@@ -40,22 +40,29 @@ impl Template {
             })?;
 
         let mut template_parser = Reader::from_reader(BufReader::new(file));
-        template_parser.expand_empty_elements(true);
         let mut buf = Vec::new();
+        let mut event_buf = Vec::new();
         loop {
             match template_parser
-                .read_event_into(&mut buf)
+                .read_event_into(&mut event_buf)
                 .map_err(Error::XmlDecodingError)?
             {
                 Event::Start(ref e) if e.local_name().as_ref() == b"template" => {
-                    buf.clear();
-                    let template = Self::parse_external_template(
-                        &mut template_parser,
-                        &mut buf,
-                        path,
-                        reader,
-                        cache,
-                    )?;
+                    let owned = e.to_owned();
+                    event_buf.clear();
+                    let elem =
+                        XmlElement::new(&mut template_parser, &mut buf, owned, false);
+                    let template =
+                        Self::parse_external_template(elem, path, reader, cache)?;
+                    return Ok(template);
+                }
+                Event::Empty(ref e) if e.local_name().as_ref() == b"template" => {
+                    let owned = e.to_owned();
+                    event_buf.clear();
+                    let elem =
+                        XmlElement::new(&mut template_parser, &mut buf, owned, true);
+                    let template =
+                        Self::parse_external_template(elem, path, reader, cache)?;
                     return Ok(template);
                 }
                 Event::Eof => {
@@ -65,13 +72,12 @@ impl Template {
                 }
                 _ => {}
             }
-            buf.clear();
+            event_buf.clear();
         }
     }
 
-    fn parse_external_template(
-        xml_reader: &mut Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
+    fn parse_external_template<R: std::io::BufRead>(
+        mut elem: XmlElement<'_, R>,
         template_path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -80,14 +86,14 @@ impl Template {
         let mut tileset = None;
         let mut tileset_gid: Vec<MapTilesetGid> = vec![];
 
-        buf.clear();
-        parse_tag!(xml_reader, buf, "template", {
-            "object" => |attrs| {
-                object = Some(ObjectData::new(xml_reader, buf, attrs, Some(&tileset_gid), tileset.clone(), template_path.parent().ok_or(Error::PathIsNotFile)?, reader, cache)?);
+        elem.buf.clear();
+        parse_tag!(&mut elem, {
+            "object" => |elem| {
+                object = Some(ObjectData::new(elem, Some(&tileset_gid), tileset.clone(), template_path.parent().ok_or(Error::PathIsNotFile)?, reader, cache)?);
                 Ok(())
             },
-            "tileset" => |attrs| {
-                let res = Tileset::parse_xml_in_map(xml_reader, buf, attrs, template_path, reader, cache)?;
+            "tileset" => |elem| {
+                let res = Tileset::parse_xml_in_map(elem, template_path, reader, cache)?;
                 match res.result_type {
                     EmbeddedParseResultType::ExternalReference { tileset_path } => {
                         tileset = Some(if let Some(ts) = cache.get_tileset(&tileset_path) {

--- a/src/template.rs
+++ b/src/template.rs
@@ -39,11 +39,9 @@ impl Template {
             })?;
 
         let mut template_parser = Reader::from_reader(BufReader::new(file));
-        parse_root_element(
-            &mut template_parser,
-            b"template",
-            |elem| Self::parse_external_template(elem, path, reader, cache),
-        )
+        parse_root_element(&mut template_parser, b"template", |elem| {
+            Self::parse_external_template(elem, path, reader, cache)
+        })
     }
 
     fn parse_external_template<R: std::io::BufRead>(

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,11 +1,13 @@
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use xml::EventReader;
-use xml::{attribute::OwnedAttribute, reader::XmlEvent};
+use quick_xml::events::Event;
+use quick_xml::Reader;
 
 use crate::{
-    util::*, EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache,
+    util::parse_tag,
+    EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache,
     ResourceReader, Result, Tileset,
 };
 
@@ -37,34 +39,39 @@ impl Template {
                 err: Box::new(err),
             })?;
 
-        let mut template_parser = EventReader::new(file);
+        let mut template_parser = Reader::from_reader(BufReader::new(file));
+        template_parser.expand_empty_elements(true);
+        let mut buf = Vec::new();
         loop {
-            match template_parser.next().map_err(Error::XmlDecodingError)? {
-                XmlEvent::StartElement {
-                    name,
-                    attributes: _,
-                    ..
-                } if name.local_name == "template" => {
+            match template_parser
+                .read_event_into(&mut buf)
+                .map_err(Error::XmlDecodingError)?
+            {
+                Event::Start(ref e) if e.local_name().as_ref() == b"template" => {
+                    buf.clear();
                     let template = Self::parse_external_template(
-                        &mut template_parser.into_iter(),
+                        &mut template_parser,
+                        &mut buf,
                         path,
                         reader,
                         cache,
                     )?;
                     return Ok(template);
                 }
-                XmlEvent::EndDocument => {
+                Event::Eof => {
                     return Err(Error::PrematureEnd(
                         "Template Document ended before template element was parsed".to_string(),
                     ))
                 }
                 _ => {}
             }
+            buf.clear();
         }
     }
 
     fn parse_external_template(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
+        xml_reader: &mut Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
         template_path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -73,13 +80,14 @@ impl Template {
         let mut tileset = None;
         let mut tileset_gid: Vec<MapTilesetGid> = vec![];
 
-        parse_tag!(parser, "template", {
+        buf.clear();
+        parse_tag!(xml_reader, buf, "template", {
             "object" => |attrs| {
-                object = Some(ObjectData::new(parser, attrs, Some(&tileset_gid), tileset.clone(), template_path.parent().ok_or(Error::PathIsNotFile)?, reader, cache)?);
+                object = Some(ObjectData::new(xml_reader, buf, attrs, Some(&tileset_gid), tileset.clone(), template_path.parent().ok_or(Error::PathIsNotFile)?, reader, cache)?);
                 Ok(())
             },
-            "tileset" => |attrs: Vec<OwnedAttribute>| {
-                let res = Tileset::parse_xml_in_map(parser, &attrs, template_path, reader, cache)?;
+            "tileset" => |attrs| {
+                let res = Tileset::parse_xml_in_map(xml_reader, buf, attrs, template_path, reader, cache)?;
                 match res.result_type {
                     EmbeddedParseResultType::ExternalReference { tileset_path } => {
                         tileset = Some(if let Some(ts) = cache.get_tileset(&tileset_path) {

--- a/src/template.rs
+++ b/src/template.rs
@@ -39,10 +39,8 @@ impl Template {
             })?;
 
         let mut template_parser = Reader::from_reader(BufReader::new(file));
-        let mut buf = Vec::new();
         parse_root_element(
             &mut template_parser,
-            &mut buf,
             b"template",
             "Template Document ended before template element was parsed",
             |elem| Self::parse_external_template(elem, path, reader, cache),

--- a/src/template.rs
+++ b/src/template.rs
@@ -42,7 +42,6 @@ impl Template {
         parse_root_element(
             &mut template_parser,
             b"template",
-            "Template Document ended before template element was parsed",
             |elem| Self::parse_external_template(elem, path, reader, cache),
         )
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -47,17 +47,13 @@ impl Template {
                 .read_event_into(&mut event_buf)
                 .map_err(Error::XmlDecodingError)?
             {
-                Event::Start(ref e) if e.local_name().as_ref() == b"template" => {
-                    let owned = e.to_owned();
-                    event_buf.clear();
-                    let elem = XmlElement::new(&mut template_parser, &mut buf, owned, false);
+                Event::Start(e) if e.local_name().as_ref() == b"template" => {
+                    let elem = XmlElement::new(&mut template_parser, &mut buf, e, false);
                     let template = Self::parse_external_template(elem, path, reader, cache)?;
                     return Ok(template);
                 }
-                Event::Empty(ref e) if e.local_name().as_ref() == b"template" => {
-                    let owned = e.to_owned();
-                    event_buf.clear();
-                    let elem = XmlElement::new(&mut template_parser, &mut buf, owned, true);
+                Event::Empty(e) if e.local_name().as_ref() == b"template" => {
+                    let elem = XmlElement::new(&mut template_parser, &mut buf, e, true);
                     let template = Self::parse_external_template(elem, path, reader, cache)?;
                     return Ok(template);
                 }
@@ -73,7 +69,7 @@ impl Template {
     }
 
     fn parse_external_template<R: std::io::BufRead>(
-        mut elem: XmlElement<'_, R>,
+        elem: XmlElement<'_, R>,
         template_path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -82,8 +78,7 @@ impl Template {
         let mut tileset = None;
         let mut tileset_gid: Vec<MapTilesetGid> = vec![];
 
-        elem.buf.clear();
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "object" => |elem| {
                 object = Some(ObjectData::new(elem, Some(&tileset_gid), tileset.clone(), template_path.parent().ok_or(Error::PathIsNotFile)?, reader, cache)?);
                 Ok(())

--- a/src/template.rs
+++ b/src/template.rs
@@ -2,11 +2,10 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use quick_xml::events::Event;
 use quick_xml::Reader;
 
 use crate::{
-    util::{parse_tag, XmlElement},
+    util::{parse_root_element, parse_tag, XmlElement},
     EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache, ResourceReader,
     Result, Tileset,
 };
@@ -41,31 +40,13 @@ impl Template {
 
         let mut template_parser = Reader::from_reader(BufReader::new(file));
         let mut buf = Vec::new();
-        let mut event_buf = Vec::new();
-        loop {
-            match template_parser
-                .read_event_into(&mut event_buf)
-                .map_err(Error::XmlDecodingError)?
-            {
-                Event::Start(e) if e.local_name().as_ref() == b"template" => {
-                    let elem = XmlElement::new(&mut template_parser, &mut buf, e, false);
-                    let template = Self::parse_external_template(elem, path, reader, cache)?;
-                    return Ok(template);
-                }
-                Event::Empty(e) if e.local_name().as_ref() == b"template" => {
-                    let elem = XmlElement::new(&mut template_parser, &mut buf, e, true);
-                    let template = Self::parse_external_template(elem, path, reader, cache)?;
-                    return Ok(template);
-                }
-                Event::Eof => {
-                    return Err(Error::PrematureEnd(
-                        "Template Document ended before template element was parsed".to_string(),
-                    ))
-                }
-                _ => {}
-            }
-            event_buf.clear();
-        }
+        parse_root_element(
+            &mut template_parser,
+            &mut buf,
+            b"template",
+            "Template Document ended before template element was parsed",
+            |elem| Self::parse_external_template(elem, path, reader, cache),
+        )
     }
 
     fn parse_external_template<R: std::io::BufRead>(

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -74,16 +74,14 @@ impl<'tileset> std::ops::Deref for Tile<'tileset> {
 }
 
 impl TileData {
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         path_relative_to: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<(TileId, TileData)> {
         let ((user_type, user_class, probability, x, y, width, height), id) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
                 Some("probability") => probability ?= v.parse(),
@@ -95,30 +93,30 @@ impl TileData {
             }
             ((user_type, user_class, probability, x, y, width, height), id)
         );
-        buf.clear();
+        elem.buf.clear();
 
         let user_type = user_type.or(user_class);
         let mut image = Option::None;
         let mut properties = HashMap::new();
         let mut objectgroup = None;
         let mut animation = None;
-        parse_tag!(xml_reader, buf, "tile", {
-            "image" => |attrs| {
-                image = Some(Image::new(xml_reader, buf, attrs, path_relative_to)?);
+        parse_tag!(&mut elem, {
+            "image" => |elem| {
+                image = Some(Image::new(elem, path_relative_to)?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
-            "objectgroup" => |attrs| {
+            "objectgroup" => |elem| {
                 // Tile objects are not allowed within tile object groups, so we can pass None as the
                 // tilesets vector
-                objectgroup = Some(ObjectLayerData::new(xml_reader, buf, attrs, None, None, path_relative_to, reader, cache)?.0);
+                objectgroup = Some(ObjectLayerData::new(elem, None, None, path_relative_to, reader, cache)?.0);
                 Ok(())
             },
-            "animation" => |_| {
-                animation = Some(parse_animation(xml_reader, buf)?);
+            "animation" => |elem| {
+                animation = Some(parse_animation(elem)?);
                 Ok(())
             },
         });

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -75,7 +75,7 @@ impl<'tileset> std::ops::Deref for Tile<'tileset> {
 
 impl TileData {
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         path_relative_to: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -93,14 +93,13 @@ impl TileData {
             }
             ((user_type, user_class, probability, x, y, width, height), id)
         );
-        elem.buf.clear();
 
         let user_type = user_type.or(user_class);
         let mut image = Option::None;
         let mut properties = HashMap::new();
         let mut objectgroup = None;
         let mut animation = None;
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "image" => |elem| {
                 image = Some(Image::new(elem, path_relative_to)?);
                 Ok(())

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,14 +1,11 @@
 use std::{collections::HashMap, path::Path};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     animation::{parse_animation, Frame},
-    error::Error,
     image::Image,
     layers::ObjectLayerData,
     properties::{parse_properties, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
     ResourceCache, ResourceReader, Result, Tileset,
 };
 
@@ -78,8 +75,9 @@ impl<'tileset> std::ops::Deref for Tile<'tileset> {
 
 impl TileData {
     pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         path_relative_to: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -97,29 +95,30 @@ impl TileData {
             }
             ((user_type, user_class, probability, x, y, width, height), id)
         );
+        buf.clear();
 
         let user_type = user_type.or(user_class);
         let mut image = Option::None;
         let mut properties = HashMap::new();
         let mut objectgroup = None;
         let mut animation = None;
-        parse_tag!(parser, "tile", {
+        parse_tag!(xml_reader, buf, "tile", {
             "image" => |attrs| {
-                image = Some(Image::new(parser, attrs, path_relative_to)?);
+                image = Some(Image::new(xml_reader, buf, attrs, path_relative_to)?);
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
             "objectgroup" => |attrs| {
                 // Tile objects are not allowed within tile object groups, so we can pass None as the
                 // tilesets vector
-                objectgroup = Some(ObjectLayerData::new(parser, attrs, None, None, path_relative_to, reader, cache)?.0);
+                objectgroup = Some(ObjectLayerData::new(xml_reader, buf, attrs, None, None, path_relative_to, reader, cache)?.0);
                 Ok(())
             },
             "animation" => |_| {
-                animation = Some(parse_animation(parser)?);
+                animation = Some(parse_animation(xml_reader, buf)?);
                 Ok(())
             },
         });

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -115,16 +115,14 @@ impl Tileset {
 }
 
 impl Tileset {
-    pub(crate) fn parse_xml_in_map(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn parse_xml_in_map<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         path: &Path, // Template or Map file
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<EmbeddedParseResult> {
-        let attrs_clone = attrs.clone();
-        Tileset::parse_xml_embedded(xml_reader, buf, attrs_clone, path, reader, cache).or_else(|err| {
+        let attrs = elem.attrs.clone();
+        Tileset::parse_xml_embedded(elem, attrs.clone(), path, reader, cache).or_else(|err| {
             if matches!(err, Error::MalformedAttributes(_)) {
                 Tileset::parse_xml_reference(attrs, path)
             } else {
@@ -133,10 +131,9 @@ impl Tileset {
         })
     }
 
-    fn parse_xml_embedded(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    fn parse_xml_embedded<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
+        attrs: quick_xml::events::BytesStart<'static>,
         path: &Path, // Template or Map file
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -145,7 +142,7 @@ impl Tileset {
             (spacing, margin, columns, name, user_type, user_class),
             (tilecount, first_gid, tile_width, tile_height),
         ) = get_attrs!(
-           for v in attrs {
+           for v in (attrs) {
             Some("spacing") => spacing ?= v.parse(),
             Some("margin") => margin ?= v.parse(),
             Some("columns") => columns ?= v.parse(),
@@ -160,13 +157,12 @@ impl Tileset {
            }
            ((spacing, margin, columns, name, user_type, user_class), (tilecount, first_gid, tile_width, tile_height))
         );
-        buf.clear();
+        elem.buf.clear();
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
 
         Self::finish_parsing_xml(
-            xml_reader,
-            buf,
+            elem,
             path.to_owned(),
             TilesetProperties {
                 spacing,
@@ -189,11 +185,11 @@ impl Tileset {
     }
 
     fn parse_xml_reference(
-        attrs: quick_xml::events::BytesStart<'_>,
+        attrs: quick_xml::events::BytesStart<'static>,
         map_path: &Path,
     ) -> Result<EmbeddedParseResult> {
         let (first_gid, source) = get_attrs!(
-            for v in attrs {
+            for v in (attrs) {
                 "firstgid" => first_gid ?= v.parse::<u32>().map(Gid),
                 "source" => source = v.to_string(),
             }
@@ -208,10 +204,8 @@ impl Tileset {
         })
     }
 
-    pub(crate) fn parse_external_tileset(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn parse_external_tileset<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -220,7 +214,7 @@ impl Tileset {
             (spacing, margin, columns, name, user_type, user_class),
             (tilecount, tile_width, tile_height),
         ) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("spacing") => spacing ?= v.parse(),
                 Some("margin") => margin ?= v.parse(),
                 Some("columns") => columns ?= v.parse(),
@@ -234,13 +228,12 @@ impl Tileset {
             }
             ((spacing, margin, columns, name, user_type, user_class), (tilecount, tile_width, tile_height))
         );
-        buf.clear();
+        elem.buf.clear();
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
 
         Self::finish_parsing_xml(
-            xml_reader,
-            buf,
+            elem,
             path.to_owned(),
             TilesetProperties {
                 spacing,
@@ -258,9 +251,8 @@ impl Tileset {
         )
     }
 
-    fn finish_parsing_xml(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
+    fn finish_parsing_xml<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
         container_path: PathBuf,
         prop: TilesetProperties,
         reader: &mut impl ResourceReader,
@@ -272,26 +264,26 @@ impl Tileset {
         let mut wang_sets = Vec::new();
         let mut offset = (0i32, 0i32);
 
-        parse_tag!(xml_reader, buf, "tileset", {
-            "image" => |attrs| {
-                image = Some(Image::new(xml_reader, buf, attrs, &prop.root_path)?);
+        parse_tag!(&mut elem, {
+            "image" => |elem| {
+                image = Some(Image::new(elem, &prop.root_path)?);
                 Ok(())
             },
-            "tileoffset" => |attrs| {
-                offset = parse_tileoffset(attrs)?;
+            "tileoffset" => |elem| {
+                offset = parse_tileoffset(elem)?;
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
-            "tile" => |attrs| {
-                let (id, tile) = TileData::new(xml_reader, buf, attrs, &prop.root_path, reader, cache)?;
+            "tile" => |elem| {
+                let (id, tile) = TileData::new(elem, &prop.root_path, reader, cache)?;
                 tiles.insert(id, tile);
                 Ok(())
             },
-            "wangset" => |attrs| {
-                let set = WangSet::new(xml_reader, buf, attrs)?;
+            "wangset" => |elem| {
+                let set = WangSet::new(elem)?;
                 wang_sets.push(set);
                 Ok(())
             },
@@ -356,12 +348,16 @@ impl Tileset {
 }
 
 /// Parse the optional <tileoffset x=... y=.../> tag.
-fn parse_tileoffset(attrs: quick_xml::events::BytesStart<'_>) -> Result<(i32, i32)> {
-    Ok(get_attrs!(
-        for v in attrs {
+fn parse_tileoffset<R: std::io::BufRead>(
+    mut elem: crate::util::XmlElement<'_, R>,
+) -> Result<(i32, i32)> {
+    let offset = get_attrs!(
+        for v in (elem.attrs) {
             "x" => offset_x ?= v.parse::<i32>(),
             "y" => offset_y ?= v.parse::<i32>(),
         }
         (offset_x, offset_y)
-    ))
+    );
+    parse_tag!(&mut elem, {});
+    Ok(offset)
 }

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -282,9 +282,14 @@ impl Tileset {
                 tiles.insert(id, tile);
                 Ok(())
             },
-            "wangset" => |elem| {
-                let set = WangSet::new(elem)?;
-                wang_sets.push(set);
+            "wangsets" => |mut elem: crate::util::XmlElement<'_, R>| {
+                parse_tag!(&mut elem, {
+                    "wangset" => |elem| {
+                        let set = WangSet::new(elem)?;
+                        wang_sets.push(set);
+                        Ok(())
+                    },
+                });
                 Ok(())
             },
         });

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -131,9 +131,9 @@ impl Tileset {
         })
     }
 
-    fn parse_xml_embedded<R: std::io::BufRead>(
-        elem: crate::util::XmlElement<'_, R>,
-        attrs: quick_xml::events::BytesStart<'static>,
+    fn parse_xml_embedded<'a, R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'a, R>,
+        attrs: quick_xml::events::BytesStart<'a>,
         path: &Path, // Template or Map file
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -157,7 +157,6 @@ impl Tileset {
            }
            ((spacing, margin, columns, name, user_type, user_class), (tilecount, first_gid, tile_width, tile_height))
         );
-        elem.buf.clear();
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
 
@@ -184,8 +183,8 @@ impl Tileset {
         })
     }
 
-    fn parse_xml_reference(
-        attrs: quick_xml::events::BytesStart<'static>,
+    fn parse_xml_reference<'a>(
+        attrs: quick_xml::events::BytesStart<'a>,
         map_path: &Path,
     ) -> Result<EmbeddedParseResult> {
         let (first_gid, source) = get_attrs!(
@@ -228,7 +227,6 @@ impl Tileset {
             }
             ((spacing, margin, columns, name, user_type, user_class), (tilecount, tile_width, tile_height))
         );
-        elem.buf.clear();
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
 
@@ -252,7 +250,7 @@ impl Tileset {
     }
 
     fn finish_parsing_xml<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
         container_path: PathBuf,
         prop: TilesetProperties,
         reader: &mut impl ResourceReader,
@@ -264,7 +262,7 @@ impl Tileset {
         let mut wang_sets = Vec::new();
         let mut offset = (0i32, 0i32);
 
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "image" => |elem| {
                 image = Some(Image::new(elem, &prop.root_path)?);
                 Ok(())
@@ -282,8 +280,8 @@ impl Tileset {
                 tiles.insert(id, tile);
                 Ok(())
             },
-            "wangsets" => |mut elem: crate::util::XmlElement<'_, R>| {
-                parse_tag!(&mut elem, {
+            "wangsets" => |elem: crate::util::XmlElement<'_, R>| {
+                parse_tag!(elem, {
                     "wangset" => |elem| {
                         let set = WangSet::new(elem)?;
                         wang_sets.push(set);
@@ -354,7 +352,7 @@ impl Tileset {
 
 /// Parse the optional <tileoffset x=... y=.../> tag.
 fn parse_tileoffset<R: std::io::BufRead>(
-    mut elem: crate::util::XmlElement<'_, R>,
+    elem: crate::util::XmlElement<'_, R>,
 ) -> Result<(i32, i32)> {
     let offset = get_attrs!(
         for v in (elem.attrs) {
@@ -363,6 +361,6 @@ fn parse_tileoffset<R: std::io::BufRead>(
         }
         (offset_x, offset_y)
     );
-    parse_tag!(&mut elem, {});
+    parse_tag!(elem, {});
     Ok(offset)
 }

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::error::{Error, Result};
 use crate::image::Image;
 use crate::properties::{parse_properties, Properties};
 use crate::tile::TileData;
-use crate::{util::*, Gid, InvalidTilesetError, ResourceCache, ResourceReader, Tile, TileId};
+use crate::{
+    util::{get_attrs, parse_tag},
+    Gid, InvalidTilesetError, ResourceCache, ResourceReader, Tile, TileId,
+};
 
 mod wangset;
 pub use wangset::*;
@@ -115,13 +116,15 @@ impl Tileset {
 
 impl Tileset {
     pub(crate) fn parse_xml_in_map(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: &[OwnedAttribute],
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         path: &Path, // Template or Map file
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<EmbeddedParseResult> {
-        Tileset::parse_xml_embedded(parser, attrs, path, reader, cache).or_else(|err| {
+        let attrs_clone = attrs.clone();
+        Tileset::parse_xml_embedded(xml_reader, buf, attrs_clone, path, reader, cache).or_else(|err| {
             if matches!(err, Error::MalformedAttributes(_)) {
                 Tileset::parse_xml_reference(attrs, path)
             } else {
@@ -131,8 +134,9 @@ impl Tileset {
     }
 
     fn parse_xml_embedded(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: &[OwnedAttribute],
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         path: &Path, // Template or Map file
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -145,7 +149,7 @@ impl Tileset {
             Some("spacing") => spacing ?= v.parse(),
             Some("margin") => margin ?= v.parse(),
             Some("columns") => columns ?= v.parse(),
-            Some("name") => name = v,
+            Some("name") => name = v.to_string(),
             Some("type") => user_type ?= v.parse(),
             Some("class") => user_class ?= v.parse(),
 
@@ -156,11 +160,13 @@ impl Tileset {
            }
            ((spacing, margin, columns, name, user_type, user_class), (tilecount, first_gid, tile_width, tile_height))
         );
+        buf.clear();
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
 
         Self::finish_parsing_xml(
-            parser,
+            xml_reader,
+            buf,
             path.to_owned(),
             TilesetProperties {
                 spacing,
@@ -183,13 +189,13 @@ impl Tileset {
     }
 
     fn parse_xml_reference(
-        attrs: &[OwnedAttribute],
+        attrs: quick_xml::events::BytesStart<'_>,
         map_path: &Path,
     ) -> Result<EmbeddedParseResult> {
         let (first_gid, source) = get_attrs!(
             for v in attrs {
                 "firstgid" => first_gid ?= v.parse::<u32>().map(Gid),
-                "source" => source = v,
+                "source" => source = v.to_string(),
             }
             (first_gid, source)
         );
@@ -203,8 +209,9 @@ impl Tileset {
     }
 
     pub(crate) fn parse_external_tileset(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: &[OwnedAttribute],
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
         path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -217,7 +224,7 @@ impl Tileset {
                 Some("spacing") => spacing ?= v.parse(),
                 Some("margin") => margin ?= v.parse(),
                 Some("columns") => columns ?= v.parse(),
-                Some("name") => name = v,
+                Some("name") => name = v.to_string(),
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
 
@@ -227,11 +234,13 @@ impl Tileset {
             }
             ((spacing, margin, columns, name, user_type, user_class), (tilecount, tile_width, tile_height))
         );
+        buf.clear();
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
 
         Self::finish_parsing_xml(
-            parser,
+            xml_reader,
+            buf,
             path.to_owned(),
             TilesetProperties {
                 spacing,
@@ -250,7 +259,8 @@ impl Tileset {
     }
 
     fn finish_parsing_xml(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
         container_path: PathBuf,
         prop: TilesetProperties,
         reader: &mut impl ResourceReader,
@@ -262,9 +272,9 @@ impl Tileset {
         let mut wang_sets = Vec::new();
         let mut offset = (0i32, 0i32);
 
-        parse_tag!(parser, "tileset", {
+        parse_tag!(xml_reader, buf, "tileset", {
             "image" => |attrs| {
-                image = Some(Image::new(parser, attrs, &prop.root_path)?);
+                image = Some(Image::new(xml_reader, buf, attrs, &prop.root_path)?);
                 Ok(())
             },
             "tileoffset" => |attrs| {
@@ -272,16 +282,16 @@ impl Tileset {
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
             "tile" => |attrs| {
-                let (id, tile) = TileData::new(parser, attrs, &prop.root_path, reader, cache)?;
+                let (id, tile) = TileData::new(xml_reader, buf, attrs, &prop.root_path, reader, cache)?;
                 tiles.insert(id, tile);
                 Ok(())
             },
             "wangset" => |attrs| {
-                let set = WangSet::new(parser, attrs)?;
+                let set = WangSet::new(xml_reader, buf, attrs)?;
                 wang_sets.push(set);
                 Ok(())
             },
@@ -346,7 +356,7 @@ impl Tileset {
 }
 
 /// Parse the optional <tileoffset x=... y=.../> tag.
-fn parse_tileoffset(attrs: Vec<OwnedAttribute>) -> Result<(i32, i32)> {
+fn parse_tileoffset(attrs: quick_xml::events::BytesStart<'_>) -> Result<(i32, i32)> {
     Ok(get_attrs!(
         for v in attrs {
             "x" => offset_x ?= v.parse::<i32>(),

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::Error,
     properties::{parse_properties, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
     Result, TileId,
 };
 
@@ -48,9 +45,10 @@ pub struct WangSet {
 
 impl WangSet {
     /// Reads data from XML parser to create a WangSet.
-    pub fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new(
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
     ) -> Result<WangSet> {
         // Get common data
         let (name, wang_set_type, tile) = get_attrs!(
@@ -61,6 +59,7 @@ impl WangSet {
             }
             (name, wang_set_type, tile)
         );
+        buf.clear();
 
         let wang_set_type = match wang_set_type.as_str() {
             "corner" => WangSetType::Corner,
@@ -73,19 +72,19 @@ impl WangSet {
         let mut wang_colors = Vec::new();
         let mut wang_tiles = HashMap::new();
         let mut properties = HashMap::new();
-        parse_tag!(parser, "wangset", {
+        parse_tag!(xml_reader, buf, "wangset", {
             "wangcolor" => |attrs| {
-                let color = WangColor::new(parser, attrs)?;
+                let color = WangColor::new(xml_reader, buf, attrs)?;
                 wang_colors.push(color);
                 Ok(())
             },
             "wangtile" => |attrs| {
-                let (id, t) = WangTile::new(parser, attrs)?;
+                let (id, t) = WangTile::new(xml_reader, buf, attrs)?;
                 wang_tiles.insert(id, t);
                 Ok(())
             },
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
         });

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -46,7 +46,7 @@ pub struct WangSet {
 impl WangSet {
     /// Reads data from XML parser to create a WangSet.
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangSet> {
         // Get common data
         let (name, wang_set_type, tile) = get_attrs!(
@@ -57,7 +57,6 @@ impl WangSet {
             }
             (name, wang_set_type, tile)
         );
-        elem.buf.clear();
 
         let wang_set_type = match wang_set_type.as_str() {
             "corner" => WangSetType::Corner,
@@ -70,7 +69,7 @@ impl WangSet {
         let mut wang_colors = Vec::new();
         let mut wang_tiles = HashMap::new();
         let mut properties = HashMap::new();
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "wangcolor" => |elem| {
                 let color = WangColor::new(elem)?;
                 wang_colors.push(color);

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -45,21 +45,19 @@ pub struct WangSet {
 
 impl WangSet {
     /// Reads data from XML parser to create a WangSet.
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangSet> {
         // Get common data
         let (name, wang_set_type, tile) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "name" => name ?= v.parse::<String>(),
                 "type" => wang_set_type ?= v.parse::<String>(),
                 "tile" => tile ?= v.parse::<i64>(),
             }
             (name, wang_set_type, tile)
         );
-        buf.clear();
+        elem.buf.clear();
 
         let wang_set_type = match wang_set_type.as_str() {
             "corner" => WangSetType::Corner,
@@ -72,19 +70,19 @@ impl WangSet {
         let mut wang_colors = Vec::new();
         let mut wang_tiles = HashMap::new();
         let mut properties = HashMap::new();
-        parse_tag!(xml_reader, buf, "wangset", {
-            "wangcolor" => |attrs| {
-                let color = WangColor::new(xml_reader, buf, attrs)?;
+        parse_tag!(&mut elem, {
+            "wangcolor" => |elem| {
+                let color = WangColor::new(elem)?;
                 wang_colors.push(color);
                 Ok(())
             },
-            "wangtile" => |attrs| {
-                let (id, t) = WangTile::new(xml_reader, buf, attrs)?;
+            "wangtile" => |elem| {
+                let (id, t) = WangTile::new(elem)?;
                 wang_tiles.insert(id, t);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::Error,
     properties::{parse_properties, Color, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
     Result, TileId,
 };
 
@@ -26,9 +23,10 @@ pub struct WangColor {
 
 impl WangColor {
     /// Reads data from XML parser to create a WangColor.
-    pub fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new(
+        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
     ) -> Result<WangColor> {
         // Get common data
         let (name, color, tile, probability) = get_attrs!(
@@ -40,14 +38,15 @@ impl WangColor {
             }
             (name, color, tile, probability)
         );
+        buf.clear();
 
         let tile = if tile >= 0 { Some(tile as u32) } else { None };
 
         // Gather variable data
         let mut properties = HashMap::new();
-        parse_tag!(parser, "wangcolor", {
+        parse_tag!(xml_reader, buf, "wangcolor", {
             "properties" => |_| {
-                properties = parse_properties(parser)?;
+                properties = parse_properties(xml_reader, buf)?;
                 Ok(())
             },
         });

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -24,7 +24,7 @@ pub struct WangColor {
 impl WangColor {
     /// Reads data from XML parser to create a WangColor.
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangColor> {
         // Get common data
         let (name, color, tile, probability) = get_attrs!(
@@ -36,13 +36,12 @@ impl WangColor {
             }
             (name, color, tile, probability)
         );
-        elem.buf.clear();
 
         let tile = if tile >= 0 { Some(tile as u32) } else { None };
 
         // Gather variable data
         let mut properties = HashMap::new();
-        parse_tag!(&mut elem, {
+        parse_tag!(elem, {
             "properties" => |elem| {
                 properties = parse_properties(elem)?;
                 Ok(())

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -23,14 +23,12 @@ pub struct WangColor {
 
 impl WangColor {
     /// Reads data from XML parser to create a WangColor.
-    pub(crate) fn new(
-        xml_reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangColor> {
         // Get common data
         let (name, color, tile, probability) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "name" => name ?= v.parse::<String>(),
                 "color" => color ?= v.parse(),
                 "tile" => tile ?= v.parse::<i64>(),
@@ -38,15 +36,15 @@ impl WangColor {
             }
             (name, color, tile, probability)
         );
-        buf.clear();
+        elem.buf.clear();
 
         let tile = if tile >= 0 { Some(tile as u32) } else { None };
 
         // Gather variable data
         let mut properties = HashMap::new();
-        parse_tag!(xml_reader, buf, "wangcolor", {
-            "properties" => |_| {
-                properties = parse_properties(xml_reader, buf)?;
+        parse_tag!(&mut elem, {
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/tileset/wangset/wang_tile.rs
+++ b/src/tileset/wangset/wang_tile.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use crate::{
     error::Error,
-    util::get_attrs,
+    util::{get_attrs, parse_tag},
     Result, TileId,
 };
 
@@ -42,20 +42,19 @@ pub struct WangTile {
 
 impl WangTile {
     /// Reads data from XML parser to create a WangTile.
-    pub(crate) fn new(
-        _reader: &mut quick_xml::Reader<impl std::io::BufRead>,
-        _buf: &mut Vec<u8>,
-        attrs: quick_xml::events::BytesStart<'_>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        mut elem: crate::util::XmlElement<'_, R>,
     ) -> Result<(TileId, WangTile)> {
         // Get common data
         let (tile_id, wang_id) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "tileid" => tile_id ?= v.parse::<u32>(),
                 "wangid" => wang_id ?= v.parse(),
             }
             (tile_id, wang_id)
         );
 
+        parse_tag!(&mut elem, {});
         Ok((tile_id, WangTile { wang_id }))
     }
 }

--- a/src/tileset/wangset/wang_tile.rs
+++ b/src/tileset/wangset/wang_tile.rs
@@ -43,7 +43,7 @@ pub struct WangTile {
 impl WangTile {
     /// Reads data from XML parser to create a WangTile.
     pub(crate) fn new<R: std::io::BufRead>(
-        mut elem: crate::util::XmlElement<'_, R>,
+        elem: crate::util::XmlElement<'_, R>,
     ) -> Result<(TileId, WangTile)> {
         // Get common data
         let (tile_id, wang_id) = get_attrs!(
@@ -54,7 +54,7 @@ impl WangTile {
             (tile_id, wang_id)
         );
 
-        parse_tag!(&mut elem, {});
+        parse_tag!(elem, {});
         Ok((tile_id, WangTile { wang_id }))
     }
 }

--- a/src/tileset/wangset/wang_tile.rs
+++ b/src/tileset/wangset/wang_tile.rs
@@ -1,10 +1,8 @@
 use std::str::FromStr;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     error::Error,
-    util::{get_attrs, XmlEventResult},
+    util::get_attrs,
     Result, TileId,
 };
 
@@ -45,8 +43,9 @@ pub struct WangTile {
 impl WangTile {
     /// Reads data from XML parser to create a WangTile.
     pub(crate) fn new(
-        _parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+        _reader: &mut quick_xml::Reader<impl std::io::BufRead>,
+        _buf: &mut Vec<u8>,
+        attrs: quick_xml::events::BytesStart<'_>,
     ) -> Result<(TileId, WangTile)> {
         // Get common data
         let (tile_id, wang_id) = get_attrs!(

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,8 +10,8 @@
 ///     $expression_to_return
 /// )
 /// ```
-/// Where `$attributes` is anything that implements `Iterator<Item = OwnedAttribute>`,
-/// and `$attr` is the value of the attribute (a String) going to be used in each branch.
+/// Where `$attributes` is anything that exposes `attributes()` for XML element attributes,
+/// and `$attr` is the value of the attribute (a &str) going to be used in each branch.
 ///
 /// Each branch indicates a variable to be set once a certain attribute is found.
 /// Its syntax is as follows:
@@ -78,9 +78,20 @@ macro_rules! get_attrs {
         {
             $crate::util::let_attr_branches!($($branches)*);
 
-            for attr in $attrs.iter() {
-                let $attr = attr.value.clone();
-                $crate::util::process_attr_branches!(attr; $($branches)*);
+            for attr in $attrs.attributes() {
+                let attr =
+                    attr.map_err(|err| $crate::Error::XmlDecodingError(err.into()))?;
+                let raw_key = attr.key.as_ref();
+                let name_bytes = match raw_key.iter().rposition(|b| *b == b':') {
+                    Some(idx) => &raw_key[idx + 1..],
+                    None => raw_key,
+                };
+                let __attr_name = std::str::from_utf8(name_bytes).unwrap_or("");
+                let __attr_value = attr
+                    .unescape_value()
+                    .map_err($crate::Error::XmlDecodingError)?;
+                let $attr = __attr_value.as_ref();
+                $crate::util::process_attr_branches!(__attr_name; $attr; $($branches)*);
             }
 
             $crate::util::handle_attr_branches!($($branches)*);
@@ -107,19 +118,19 @@ macro_rules! let_attr_branches {
 pub(crate) use let_attr_branches;
 
 macro_rules! process_attr_branches {
-    ($attr:ident; ) => {};
+    ($name:ident; $value:ident; ) => {};
 
-    ($attr:ident; Some($attr_pat_opt:literal) => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if(&$attr.name.local_name == $attr_pat_opt) {
+    ($name:ident; $value:ident; Some($attr_pat_opt:literal) => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
+        if $name == $attr_pat_opt {
             $opt_var = Some($opt_expr);
         }
         else {
-            $crate::util::process_attr_branches!($attr; $($($tail)*)?);
+            $crate::util::process_attr_branches!($name; $value; $($($tail)*)?);
         }
     };
 
-    ($attr:ident; Some($attr_pat_opt:literal) => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if(&$attr.name.local_name == $attr_pat_opt) {
+    ($name:ident; $value:ident; Some($attr_pat_opt:literal) => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
+        if $name == $attr_pat_opt {
             $opt_var = Some($opt_expr.map_err(|_|
                 $crate::Error::MalformedAttributes(
                     concat!("Error parsing optional attribute '", $attr_pat_opt, "'").to_owned()
@@ -127,21 +138,21 @@ macro_rules! process_attr_branches {
             )?);
         }
         else {
-            $crate::util::process_attr_branches!($attr; $($($tail)*)?);
+            $crate::util::process_attr_branches!($name; $value; $($($tail)*)?);
         }
     };
 
-    ($attr:ident; $attr_pat_opt:literal => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if(&$attr.name.local_name == $attr_pat_opt) {
+    ($name:ident; $value:ident; $attr_pat_opt:literal => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
+        if $name == $attr_pat_opt {
             $opt_var = Some($opt_expr);
         }
         else {
-            $crate::util::process_attr_branches!($attr; $($($tail)*)?);
+            $crate::util::process_attr_branches!($name; $value; $($($tail)*)?);
         }
     };
 
-    ($attr:ident; $attr_pat_opt:literal => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if(&$attr.name.local_name == $attr_pat_opt) {
+    ($name:ident; $value:ident; $attr_pat_opt:literal => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
+        if $name == $attr_pat_opt {
             $opt_var = Some($opt_expr.map_err(|_|
                 $crate::Error::MalformedAttributes(
                     concat!("Error parsing attribute '", $attr_pat_opt, "'").to_owned()
@@ -149,7 +160,7 @@ macro_rules! process_attr_branches {
             )?);
         }
         else {
-            $crate::util::process_attr_branches!($attr; $($($tail)*)?);
+            $crate::util::process_attr_branches!($name; $value; $($($tail)*)?);
         }
     }
 }
@@ -166,7 +177,7 @@ macro_rules! handle_attr_branches {
     ($attr_pat_opt:literal => $opt_var:ident $(?)?= $opt_expr:expr $(, $($tail:tt)*)?) => {
         let $opt_var = $opt_var
             .ok_or_else(||
-                Error::MalformedAttributes(
+                $crate::Error::MalformedAttributes(
                     concat!("Missing attribute: ", $attr_pat_opt).to_owned()
                 )
             )?;
@@ -180,27 +191,38 @@ pub(crate) use handle_attr_branches;
 /// Goes through the children of the tag and will call the correct function for
 /// that child. Closes the tag.
 macro_rules! parse_tag {
-    ($parser:expr, $close_tag:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {
-        while let Some(next) = $parser.next() {
-            match next.map_err(Error::XmlDecodingError)? {
+    ($reader:expr, $buf:expr, $close_tag:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {
+        let mut __event_buf = Vec::new();
+        loop {
+            match $reader
+                .read_event_into(&mut __event_buf)
+                .map_err($crate::Error::XmlDecodingError)?
+            {
                 #[allow(unused_variables)]
-                $(
-                    xml::reader::XmlEvent::StartElement {name, attributes, ..}
-                        if name.local_name == $open_tag => $open_method(attributes)?,
-                )*
-
-
-                xml::reader::XmlEvent::EndElement {name, ..} => if name.local_name == $close_tag {
+                quick_xml::events::Event::Start(e) => {
+                    let name = e.local_name();
+                    $(
+                        if name.as_ref() == $open_tag.as_bytes() {
+                            $open_method(e.into_owned())?;
+                            __event_buf.clear();
+                            continue;
+                        }
+                    )*
+                }
+                quick_xml::events::Event::End(e) if e.local_name().as_ref() == $close_tag.as_bytes() => {
+                    __event_buf.clear();
                     break;
                 }
-
-                xml::reader::XmlEvent::EndDocument => {
-                    return Err(Error::PrematureEnd("Document ended before we expected.".to_string()));
+                quick_xml::events::Event::Eof => {
+                    return Err($crate::Error::PrematureEnd(
+                        "Document ended before we expected.".to_string(),
+                    ));
                 }
                 _ => {}
             }
+            __event_buf.clear();
         }
-    }
+    };
 }
 
 /// Creates a new type that wraps an internal data type over along with a map.
@@ -243,7 +265,6 @@ pub(crate) use parse_tag;
 
 use crate::{Gid, MapTilesetGid};
 
-pub(crate) type XmlEventResult = xml::reader::Result<xml::reader::XmlEvent>;
 
 /// Returns both the tileset and its index
 pub(crate) fn get_tileset_for_gid(

--- a/src/util.rs
+++ b/src/util.rs
@@ -195,8 +195,7 @@ macro_rules! parse_tag {
     ($elem:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {{
         let __elem = $elem;
         if !__elem.is_empty {
-            let (reader, buf) = __elem.into_reader_and_buf();
-            let _ = &buf;
+            let reader = __elem.into_reader();
             let mut __event_buf = Vec::new();
             loop {
                 __event_buf.clear();
@@ -209,7 +208,7 @@ macro_rules! parse_tag {
                         $(
                             if e.local_name().as_ref() == $open_tag.as_bytes() {
                                 let mut __child =
-                                    $crate::util::XmlElement::new(&mut *reader, &mut *buf, e, false);
+                                    $crate::util::XmlElement::new(&mut *reader, e, false);
                                 $open_method(__child)?;
                                 continue;
                             }
@@ -225,7 +224,7 @@ macro_rules! parse_tag {
                         $(
                             if e.local_name().as_ref() == $open_tag.as_bytes() {
                                 let mut __child =
-                                    $crate::util::XmlElement::new(&mut *reader, &mut *buf, e, true);
+                                    $crate::util::XmlElement::new(&mut *reader, e, true);
                                 $open_method(__child)?;
                                 continue;
                             }
@@ -316,7 +315,6 @@ use crate::{Error, Result};
 
 pub(crate) struct XmlElement<'a, R: BufRead> {
     reader: &'a mut Reader<R>,
-    buf: &'a mut Vec<u8>,
     pub attrs: BytesStart<'a>,
     pub is_empty: bool,
 }
@@ -324,20 +322,18 @@ pub(crate) struct XmlElement<'a, R: BufRead> {
 impl<'a, R: BufRead> XmlElement<'a, R> {
     pub(crate) fn new(
         reader: &'a mut Reader<R>,
-        buf: &'a mut Vec<u8>,
         attrs: BytesStart<'a>,
         is_empty: bool,
     ) -> Self {
         Self {
             reader,
-            buf,
             attrs,
             is_empty,
         }
     }
 
-    pub(crate) fn into_reader_and_buf(self) -> (&'a mut Reader<R>, &'a mut Vec<u8>) {
-        (self.reader, self.buf)
+    pub(crate) fn into_reader(self) -> &'a mut Reader<R> {
+        self.reader
     }
 }
 
@@ -349,12 +345,13 @@ pub(crate) fn read_text_or_cdata<R: BufRead>(
         return Ok(None);
     }
 
-    let (reader, buf) = elem.into_reader_and_buf();
+    let reader = elem.into_reader();
+    let mut event_buf = Vec::new();
     let mut text = None;
     loop {
-        buf.clear();
+        event_buf.clear();
         match reader
-            .read_event_into(buf)
+            .read_event_into(&mut event_buf)
             .map_err(Error::XmlDecodingError)?
         {
             Event::Text(e) => {
@@ -378,7 +375,6 @@ pub(crate) fn read_text_or_cdata<R: BufRead>(
 
 pub(crate) fn parse_root_element<R, F, T>(
     reader: &mut Reader<R>,
-    buf: &mut Vec<u8>,
     tag: &[u8],
     eof_message: &str,
     mut handler: F,
@@ -394,12 +390,10 @@ where
             .map_err(Error::XmlDecodingError)?
         {
             Event::Start(e) if e.local_name().as_ref() == tag => {
-                let elem = XmlElement::new(reader, buf, e, false);
-                return handler(elem);
+                return handler(XmlElement::new(reader, e, false));
             }
             Event::Empty(e) if e.local_name().as_ref() == tag => {
-                let elem = XmlElement::new(reader, buf, e, true);
-                return handler(elem);
+                return handler(XmlElement::new(reader, e, true));
             }
             Event::Eof => {
                 return Err(Error::PrematureEnd(eof_message.to_string()));

--- a/src/util.rs
+++ b/src/util.rs
@@ -197,6 +197,7 @@ macro_rules! parse_tag {
         if !__elem.is_empty {
             let mut __event_buf = Vec::new();
             loop {
+                __event_buf.clear();
                 match __elem
                     .reader
                     .read_event_into(&mut __event_buf)
@@ -204,30 +205,33 @@ macro_rules! parse_tag {
                 {
                     #[allow(unused_variables)]
                     quick_xml::events::Event::Start(e) => {
-                        let name = e.local_name();
+                        let owned = e.into_owned();
+                        let name = owned.local_name();
                         $(
                             if name.as_ref() == $open_tag.as_bytes() {
-                                let mut __child = __elem.child(e.into_owned(), false);
+                                let mut __child = __elem.child(owned, false);
                                 $open_method(__child)?;
-                                __event_buf.clear();
                                 continue;
                             }
                         )*
+                        __elem
+                            .reader
+                            .read_to_end_into(owned.name(), &mut __event_buf)
+                            .map_err($crate::Error::XmlDecodingError)?;
                     }
                     #[allow(unused_variables)]
                     quick_xml::events::Event::Empty(e) => {
-                        let name = e.local_name();
+                        let owned = e.into_owned();
+                        let name = owned.local_name();
                         $(
                             if name.as_ref() == $open_tag.as_bytes() {
-                                let mut __child = __elem.child(e.into_owned(), true);
+                                let mut __child = __elem.child(owned, true);
                                 $open_method(__child)?;
-                                __event_buf.clear();
                                 continue;
                             }
                         )*
                     }
                     quick_xml::events::Event::End(_) => {
-                        __event_buf.clear();
                         break;
                     }
                     quick_xml::events::Event::Eof => {
@@ -237,7 +241,6 @@ macro_rules! parse_tag {
                     }
                     _ => {}
                 }
-                __event_buf.clear();
             }
         }
     }};

--- a/src/util.rs
+++ b/src/util.rs
@@ -375,3 +375,37 @@ pub(crate) fn read_text_or_cdata<R: BufRead>(
     }
     Ok(text)
 }
+
+pub(crate) fn parse_root_element<R, F, T>(
+    reader: &mut Reader<R>,
+    buf: &mut Vec<u8>,
+    tag: &[u8],
+    eof_message: &str,
+    mut handler: F,
+) -> Result<T>
+where
+    R: BufRead,
+    F: FnMut(XmlElement<'_, R>) -> Result<T>,
+{
+    let mut event_buf = Vec::new();
+    loop {
+        match reader
+            .read_event_into(&mut event_buf)
+            .map_err(Error::XmlDecodingError)?
+        {
+            Event::Start(e) if e.local_name().as_ref() == tag => {
+                let elem = XmlElement::new(reader, buf, e, false);
+                return handler(elem);
+            }
+            Event::Empty(e) if e.local_name().as_ref() == tag => {
+                let elem = XmlElement::new(reader, buf, e, true);
+                return handler(elem);
+            }
+            Event::Eof => {
+                return Err(Error::PrematureEnd(eof_message.to_string()));
+            }
+            _ => {}
+        }
+        event_buf.clear();
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -195,37 +195,37 @@ macro_rules! parse_tag {
     ($elem:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {{
         let __elem = $elem;
         if !__elem.is_empty {
+            let (reader, buf) = __elem.into_reader_and_buf();
+            let _ = &buf;
             let mut __event_buf = Vec::new();
             loop {
                 __event_buf.clear();
-                match __elem
-                    .reader
+                match reader
                     .read_event_into(&mut __event_buf)
                     .map_err($crate::Error::XmlDecodingError)?
                 {
                     #[allow(unused_variables)]
                     quick_xml::events::Event::Start(e) => {
-                        let owned = e.into_owned();
-                        let name = owned.local_name();
                         $(
-                            if name.as_ref() == $open_tag.as_bytes() {
-                                let mut __child = __elem.child(owned, false);
+                            if e.local_name().as_ref() == $open_tag.as_bytes() {
+                                let mut __child =
+                                    $crate::util::XmlElement::new(&mut *reader, &mut *buf, e, false);
                                 $open_method(__child)?;
                                 continue;
                             }
                         )*
-                        __elem
-                            .reader
-                            .read_to_end_into(owned.name(), &mut __event_buf)
+                        let end = e.to_end().into_owned();
+                        drop(e);
+                        reader
+                            .read_to_end_into(end.name(), &mut __event_buf)
                             .map_err($crate::Error::XmlDecodingError)?;
                     }
                     #[allow(unused_variables)]
                     quick_xml::events::Event::Empty(e) => {
-                        let owned = e.into_owned();
-                        let name = owned.local_name();
                         $(
-                            if name.as_ref() == $open_tag.as_bytes() {
-                                let mut __child = __elem.child(owned, true);
+                            if e.local_name().as_ref() == $open_tag.as_bytes() {
+                                let mut __child =
+                                    $crate::util::XmlElement::new(&mut *reader, &mut *buf, e, true);
                                 $open_method(__child)?;
                                 continue;
                             }
@@ -315,9 +315,9 @@ use quick_xml::{events::BytesStart, events::Event, Reader};
 use crate::{Error, Result};
 
 pub(crate) struct XmlElement<'a, R: BufRead> {
-    pub reader: &'a mut Reader<R>,
-    pub buf: &'a mut Vec<u8>,
-    pub attrs: BytesStart<'static>,
+    reader: &'a mut Reader<R>,
+    buf: &'a mut Vec<u8>,
+    pub attrs: BytesStart<'a>,
     pub is_empty: bool,
 }
 
@@ -325,7 +325,7 @@ impl<'a, R: BufRead> XmlElement<'a, R> {
     pub(crate) fn new(
         reader: &'a mut Reader<R>,
         buf: &'a mut Vec<u8>,
-        attrs: BytesStart<'static>,
+        attrs: BytesStart<'a>,
         is_empty: bool,
     ) -> Self {
         Self {
@@ -336,52 +336,40 @@ impl<'a, R: BufRead> XmlElement<'a, R> {
         }
     }
 
-    pub(crate) fn child(
-        &mut self,
-        attrs: BytesStart<'static>,
-        is_empty: bool,
-    ) -> XmlElement<'_, R> {
-        XmlElement {
-            reader: &mut *self.reader,
-            buf: &mut *self.buf,
-            attrs,
-            is_empty,
-        }
+    pub(crate) fn into_reader_and_buf(self) -> (&'a mut Reader<R>, &'a mut Vec<u8>) {
+        (self.reader, self.buf)
     }
 }
 
 pub(crate) fn read_text_or_cdata<R: BufRead>(
-    elem: &mut XmlElement<'_, R>,
+    elem: XmlElement<'_, R>,
     eof_message: &str,
 ) -> Result<Option<String>> {
     if elem.is_empty {
         return Ok(None);
     }
 
+    let (reader, buf) = elem.into_reader_and_buf();
     let mut text = None;
     loop {
-        match elem
-            .reader
-            .read_event_into(elem.buf)
+        buf.clear();
+        match reader
+            .read_event_into(buf)
             .map_err(Error::XmlDecodingError)?
         {
             Event::Text(e) => {
                 text = Some(e.unescape().map_err(Error::XmlDecodingError)?.into_owned());
-                elem.buf.clear();
             }
             Event::CData(e) => {
                 text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
-                elem.buf.clear();
             }
             Event::End(_) => {
-                elem.buf.clear();
                 break;
             }
             Event::Eof => {
                 return Err(Error::PrematureEnd(eof_message.to_owned()));
             }
             _ => {
-                elem.buf.clear();
             }
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,14 +4,15 @@
 /// The syntax is:
 /// ```ignore
 /// get_attrs!(
-///     for $attr in $attributes {
+///     for $attr in ($attributes) {
 ///         $($branch),*
 ///     }
 ///     $expression_to_return
 /// )
 /// ```
 /// Where `$attributes` is anything that exposes `attributes()` for XML element attributes,
-/// and `$attr` is the value of the attribute (a &str) going to be used in each branch.
+/// and `$attr` is the value of the attribute (a &str) going to be used in each branch. The
+/// `$attributes` expression must be parenthesized to satisfy macro parsing.
 ///
 /// Each branch indicates a variable to be set once a certain attribute is found.
 /// Its syntax is as follows:
@@ -21,16 +22,16 @@
 ///
 /// For instance:
 /// ```ignore
-/// "source" => source = v,
+/// "source" => source = v.to_string(),
 /// ```
-/// The variable set has an inferred type `T`. In this case, `source` is inferred to be a `String`,
-/// and `$attr` has been named `v`.
+/// The variable set has an inferred type `T`. In this case, `source` is inferred to be a `String`
+/// because we call `to_string()`, and `$attr` has been named `v`.
 ///
 /// If `Some` encapsulates the attribute name (like so: `Some("attribute name")`) then the attribute
 /// is meant to be optional, which will make the variable an `Option<T>` rather than `T`. Even if it
 /// is technically an Option, the assignment is still done *as if it was `T`*, for instance:
 /// ```ignore
-/// Some("name") => name = v,
+/// Some("name") => name = v.to_string(),
 /// ```
 ///
 /// Finally, branches can also use `?=` instead of `=`, which will make them accept a `Result<T, E>`
@@ -42,7 +43,7 @@
 /// Some("spacing") => spacing ?= v.parse(),
 /// Some("margin") => margin ?= v.parse(),
 /// Some("columns") => columns ?= v.parse(),
-/// Some("name") => name = v,
+/// Some("name") => name = v.to_string(),
 ///
 /// "tilecount" => tilecount ?= v.parse::<u32>(),
 /// "tilewidth" => tile_width ?= v.parse::<u32>(),
@@ -55,10 +56,10 @@
 /// ## Example
 /// ```ignore
 /// let ((c, infinite), (v, o, w, h, tw, th)) = get_attrs!(
-///     for v in attrs {
+///     for v in (attrs) {
 ///         Some("backgroundcolor") => colour ?= v.parse(),
 ///         Some("infinite") => infinite = v == "1",
-///         "version" => version = v,
+///         "version" => version = v.to_string(),
 ///         "orientation" => orientation ?= v.parse::<Orientation>(),
 ///         "width" => width ?= v.parse::<u32>(),
 ///         "height" => height ?= v.parse::<u32>(),
@@ -70,7 +71,7 @@
 /// ```
 macro_rules! get_attrs {
     (
-        for $attr:ident in $attrs:ident {
+        for $attr:ident in ($attrs:expr) {
             $($branches:tt)*
         }
         $ret_expr:expr
@@ -78,7 +79,7 @@ macro_rules! get_attrs {
         {
             $crate::util::let_attr_branches!($($branches)*);
 
-            for attr in $attrs.attributes() {
+            for attr in ($attrs).attributes() {
                 let attr =
                     attr.map_err(|err| $crate::Error::XmlDecodingError(err.into()))?;
                 let raw_key = attr.key.as_ref();
@@ -191,38 +192,55 @@ pub(crate) use handle_attr_branches;
 /// Goes through the children of the tag and will call the correct function for
 /// that child. Closes the tag.
 macro_rules! parse_tag {
-    ($reader:expr, $buf:expr, $close_tag:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {
-        let mut __event_buf = Vec::new();
-        loop {
-            match $reader
-                .read_event_into(&mut __event_buf)
-                .map_err($crate::Error::XmlDecodingError)?
-            {
-                #[allow(unused_variables)]
-                quick_xml::events::Event::Start(e) => {
-                    let name = e.local_name();
-                    $(
-                        if name.as_ref() == $open_tag.as_bytes() {
-                            $open_method(e.into_owned())?;
-                            __event_buf.clear();
-                            continue;
-                        }
-                    )*
+    ($elem:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {{
+        let __elem = $elem;
+        if !__elem.is_empty {
+            let mut __event_buf = Vec::new();
+            loop {
+                match __elem
+                    .reader
+                    .read_event_into(&mut __event_buf)
+                    .map_err($crate::Error::XmlDecodingError)?
+                {
+                    #[allow(unused_variables)]
+                    quick_xml::events::Event::Start(e) => {
+                        let name = e.local_name();
+                        $(
+                            if name.as_ref() == $open_tag.as_bytes() {
+                                let mut __child = __elem.child(e.into_owned(), false);
+                                $open_method(__child)?;
+                                __event_buf.clear();
+                                continue;
+                            }
+                        )*
+                    }
+                    #[allow(unused_variables)]
+                    quick_xml::events::Event::Empty(e) => {
+                        let name = e.local_name();
+                        $(
+                            if name.as_ref() == $open_tag.as_bytes() {
+                                let mut __child = __elem.child(e.into_owned(), true);
+                                $open_method(__child)?;
+                                __event_buf.clear();
+                                continue;
+                            }
+                        )*
+                    }
+                    quick_xml::events::Event::End(_) => {
+                        __event_buf.clear();
+                        break;
+                    }
+                    quick_xml::events::Event::Eof => {
+                        return Err($crate::Error::PrematureEnd(
+                            "Document ended before we expected.".to_string(),
+                        ));
+                    }
+                    _ => {}
                 }
-                quick_xml::events::Event::End(e) if e.local_name().as_ref() == $close_tag.as_bytes() => {
-                    __event_buf.clear();
-                    break;
-                }
-                quick_xml::events::Event::Eof => {
-                    return Err($crate::Error::PrematureEnd(
-                        "Document ended before we expected.".to_string(),
-                    ));
-                }
-                _ => {}
+                __event_buf.clear();
             }
-            __event_buf.clear();
         }
-    };
+    }};
 }
 
 /// Creates a new type that wraps an internal data type over along with a map.
@@ -286,5 +304,40 @@ pub fn floor_div(a: i32, b: i32) -> i32 {
         d
     } else {
         d - ((a < 0) ^ (b < 0)) as i32
+    }
+}
+use std::io::BufRead;
+
+use quick_xml::{events::BytesStart, Reader};
+
+pub(crate) struct XmlElement<'a, R: BufRead> {
+    pub reader: &'a mut Reader<R>,
+    pub buf: &'a mut Vec<u8>,
+    pub attrs: BytesStart<'static>,
+    pub is_empty: bool,
+}
+
+impl<'a, R: BufRead> XmlElement<'a, R> {
+    pub(crate) fn new(
+        reader: &'a mut Reader<R>,
+        buf: &'a mut Vec<u8>,
+        attrs: BytesStart<'static>,
+        is_empty: bool,
+    ) -> Self {
+        Self {
+            reader,
+            buf,
+            attrs,
+            is_empty,
+        }
+    }
+
+    pub(crate) fn child(&mut self, attrs: BytesStart<'static>, is_empty: bool) -> XmlElement<'_, R> {
+        XmlElement {
+            reader: &mut *self.reader,
+            buf: &mut *self.buf,
+            attrs,
+            is_empty,
+        }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -195,40 +195,15 @@ macro_rules! parse_tag {
     ($elem:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {{
         let __elem = $elem;
         if !__elem.is_empty {
-            let reader = __elem.into_reader();
-            let mut event_buf = Vec::new();
+            let __reader = __elem.into_reader();
+            let mut __event_buf = Vec::new();
             loop {
-                match reader
-                    .read_event_into(&mut event_buf)
+                let e = match __reader
+                    .read_event_into(&mut __event_buf)
                     .map_err($crate::Error::XmlDecodingError)?
                 {
-                    #[allow(unused_variables)]
-                    quick_xml::events::Event::Start(e) => {
-                        $(
-                            if e.local_name().as_ref() == $open_tag.as_bytes() {
-                                let mut __child =
-                                    $crate::util::XmlElement::new(&mut *reader, e, false);
-                                $open_method(__child)?;
-                                continue;
-                            }
-                        )*
-                        let end = e.to_end().into_owned();
-                        drop(e);
-                        reader
-                            .read_to_end_into(end.name(), &mut event_buf)
-                            .map_err($crate::Error::XmlDecodingError)?;
-                    }
-                    #[allow(unused_variables)]
-                    quick_xml::events::Event::Empty(e) => {
-                        $(
-                            if e.local_name().as_ref() == $open_tag.as_bytes() {
-                                let mut __child =
-                                    $crate::util::XmlElement::new(&mut *reader, e, true);
-                                $open_method(__child)?;
-                                continue;
-                            }
-                        )*
-                    }
+                    quick_xml::events::Event::Start(e) => Some((e, false)),
+                    quick_xml::events::Event::Empty(e) => Some((e, true)),
                     quick_xml::events::Event::End(_) => {
                         break;
                     }
@@ -237,7 +212,28 @@ macro_rules! parse_tag {
                             "Document ended before we expected.".to_string(),
                         ));
                     }
-                    _ => {}
+                    _ => None,
+                };
+
+                if let Some((e, is_empty)) = e {
+                    match e.local_name().as_ref() {
+                        $(
+                            name if name == $open_tag.as_bytes() => {
+                                let mut __child =
+                                    $crate::util::XmlElement::new(&mut *__reader, e, is_empty);
+                                $open_method(__child)?;
+                            }
+                        )*
+                        _ => {
+                            if !is_empty {
+                                let end = e.to_end().into_owned();
+                                drop(e);
+                                __reader
+                                    .read_to_end_into(end.name(), &mut __event_buf)
+                                    .map_err($crate::Error::XmlDecodingError)?;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -308,7 +308,9 @@ pub fn floor_div(a: i32, b: i32) -> i32 {
 }
 use std::io::BufRead;
 
-use quick_xml::{events::BytesStart, Reader};
+use quick_xml::{events::BytesStart, events::Event, Reader};
+
+use crate::{Error, Result};
 
 pub(crate) struct XmlElement<'a, R: BufRead> {
     pub reader: &'a mut Reader<R>,
@@ -340,4 +342,42 @@ impl<'a, R: BufRead> XmlElement<'a, R> {
             is_empty,
         }
     }
+}
+
+pub(crate) fn read_text_or_cdata<R: BufRead>(
+    elem: &mut XmlElement<'_, R>,
+    eof_message: &str,
+) -> Result<Option<String>> {
+    if elem.is_empty {
+        return Ok(None);
+    }
+
+    let mut text = None;
+    loop {
+        match elem
+            .reader
+            .read_event_into(elem.buf)
+            .map_err(Error::XmlDecodingError)?
+        {
+            Event::Text(e) => {
+                text = Some(e.unescape().map_err(Error::XmlDecodingError)?.into_owned());
+                elem.buf.clear();
+            }
+            Event::CData(e) => {
+                text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
+                elem.buf.clear();
+            }
+            Event::End(_) => {
+                elem.buf.clear();
+                break;
+            }
+            Event::Eof => {
+                return Err(Error::PrematureEnd(eof_message.to_owned()));
+            }
+            _ => {
+                elem.buf.clear();
+            }
+        }
+    }
+    Ok(text)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -82,12 +82,8 @@ macro_rules! get_attrs {
             for attr in ($attrs).attributes() {
                 let attr =
                     attr.map_err(|err| $crate::Error::XmlDecodingError(err.into()))?;
-                let raw_key = attr.key.as_ref();
-                let name_bytes = match raw_key.iter().rposition(|b| *b == b':') {
-                    Some(idx) => &raw_key[idx + 1..],
-                    None => raw_key,
-                };
-                let __attr_name = std::str::from_utf8(name_bytes).unwrap_or("");
+                let local_name = attr.key.local_name();
+                let __attr_name = local_name.as_ref();
                 let __attr_value = attr
                     .unescape_value()
                     .map_err($crate::Error::XmlDecodingError)?;
@@ -122,7 +118,7 @@ macro_rules! process_attr_branches {
     ($name:ident; $value:ident; ) => {};
 
     ($name:ident; $value:ident; Some($attr_pat_opt:literal) => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if $name == $attr_pat_opt {
+        if $name == $attr_pat_opt.as_bytes() {
             $opt_var = Some($opt_expr);
         }
         else {
@@ -131,7 +127,7 @@ macro_rules! process_attr_branches {
     };
 
     ($name:ident; $value:ident; Some($attr_pat_opt:literal) => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if $name == $attr_pat_opt {
+        if $name == $attr_pat_opt.as_bytes() {
             $opt_var = Some($opt_expr.map_err(|_|
                 $crate::Error::MalformedAttributes(
                     concat!("Error parsing optional attribute '", $attr_pat_opt, "'").to_owned()
@@ -144,7 +140,7 @@ macro_rules! process_attr_branches {
     };
 
     ($name:ident; $value:ident; $attr_pat_opt:literal => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if $name == $attr_pat_opt {
+        if $name == $attr_pat_opt.as_bytes() {
             $opt_var = Some($opt_expr);
         }
         else {
@@ -153,7 +149,7 @@ macro_rules! process_attr_branches {
     };
 
     ($name:ident; $value:ident; $attr_pat_opt:literal => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if $name == $attr_pat_opt {
+        if $name == $attr_pat_opt.as_bytes() {
             $opt_var = Some($opt_expr.map_err(|_|
                 $crate::Error::MalformedAttributes(
                     concat!("Error parsing attribute '", $attr_pat_opt, "'").to_owned()

--- a/src/util.rs
+++ b/src/util.rs
@@ -324,38 +324,50 @@ impl<'a, R: BufRead> XmlElement<'a, R> {
     }
 }
 
-pub(crate) fn read_text_or_cdata<R: BufRead>(
+pub(crate) fn read_text_or_cdata<R: BufRead, F, T>(
     elem: XmlElement<'_, R>,
-    eof_message: &str,
-) -> Result<Option<String>> {
+    mut handler: F,
+) -> Result<T>
+where
+    F: for<'a> FnMut(&'a str) -> Result<T>,
+{
     if elem.is_empty {
-        return Ok(None);
+        return handler("");
     }
 
     let reader = elem.into_reader();
     let mut event_buf = Vec::new();
-    let mut text = None;
+    let mut result = None;
     loop {
         match reader
             .read_event_into(&mut event_buf)
             .map_err(Error::XmlDecodingError)?
         {
-            Event::Text(e) => {
-                text = Some(e.unescape().map_err(Error::XmlDecodingError)?.into_owned());
+            Event::Text(e) if result.is_none() => {
+                let unescaped = e.unescape().map_err(Error::XmlDecodingError)?;
+                result = Some(Ok(handler(unescaped.as_ref())?));
             }
-            Event::CData(e) => {
-                text = Some(String::from_utf8_lossy(e.as_ref()).into_owned());
+            Event::CData(e) if result.is_none() => {
+                let unescaped = String::from_utf8_lossy(e.as_ref());
+                result = Some(Ok(handler(unescaped.as_ref())?));
             }
-            Event::End(_) => {
-                break;
+            Event::Start(e) => {
+                let end = e.to_end().into_owned();
+                drop(e);
+                reader
+                    .read_to_end_into(end.name(), &mut event_buf)
+                    .map_err(Error::XmlDecodingError)?;
             }
+            Event::Empty(_) => {}
+            Event::End(_) => return result.unwrap_or_else(|| handler("")),
             Event::Eof => {
-                return Err(Error::PrematureEnd(eof_message.to_owned()));
+                return Err(Error::PrematureEnd(
+                    "end of file while reading element contents".to_owned(),
+                ));
             }
             _ => {}
         }
     }
-    Ok(text)
 }
 
 pub(crate) fn parse_root_element<R, F, T>(

--- a/src/util.rs
+++ b/src/util.rs
@@ -286,7 +286,6 @@ pub(crate) use parse_tag;
 
 use crate::{Gid, MapTilesetGid};
 
-
 /// Returns both the tileset and its index
 pub(crate) fn get_tileset_for_gid(
     tilesets: &[MapTilesetGid],
@@ -337,7 +336,11 @@ impl<'a, R: BufRead> XmlElement<'a, R> {
         }
     }
 
-    pub(crate) fn child(&mut self, attrs: BytesStart<'static>, is_empty: bool) -> XmlElement<'_, R> {
+    pub(crate) fn child(
+        &mut self,
+        attrs: BytesStart<'static>,
+        is_empty: bool,
+    ) -> XmlElement<'_, R> {
         XmlElement {
             reader: &mut *self.reader,
             buf: &mut *self.buf,

--- a/src/util.rs
+++ b/src/util.rs
@@ -196,11 +196,10 @@ macro_rules! parse_tag {
         let __elem = $elem;
         if !__elem.is_empty {
             let reader = __elem.into_reader();
-            let mut __event_buf = Vec::new();
+            let mut event_buf = Vec::new();
             loop {
-                __event_buf.clear();
                 match reader
-                    .read_event_into(&mut __event_buf)
+                    .read_event_into(&mut event_buf)
                     .map_err($crate::Error::XmlDecodingError)?
                 {
                     #[allow(unused_variables)]
@@ -216,7 +215,7 @@ macro_rules! parse_tag {
                         let end = e.to_end().into_owned();
                         drop(e);
                         reader
-                            .read_to_end_into(end.name(), &mut __event_buf)
+                            .read_to_end_into(end.name(), &mut event_buf)
                             .map_err($crate::Error::XmlDecodingError)?;
                     }
                     #[allow(unused_variables)]
@@ -349,7 +348,6 @@ pub(crate) fn read_text_or_cdata<R: BufRead>(
     let mut event_buf = Vec::new();
     let mut text = None;
     loop {
-        event_buf.clear();
         match reader
             .read_event_into(&mut event_buf)
             .map_err(Error::XmlDecodingError)?
@@ -366,8 +364,7 @@ pub(crate) fn read_text_or_cdata<R: BufRead>(
             Event::Eof => {
                 return Err(Error::PrematureEnd(eof_message.to_owned()));
             }
-            _ => {
-            }
+            _ => {}
         }
     }
     Ok(text)
@@ -376,7 +373,6 @@ pub(crate) fn read_text_or_cdata<R: BufRead>(
 pub(crate) fn parse_root_element<R, F, T>(
     reader: &mut Reader<R>,
     tag: &[u8],
-    eof_message: &str,
     mut handler: F,
 ) -> Result<T>
 where
@@ -385,21 +381,38 @@ where
 {
     let mut event_buf = Vec::new();
     loop {
-        match reader
+        let e = match reader
             .read_event_into(&mut event_buf)
             .map_err(Error::XmlDecodingError)?
         {
-            Event::Start(e) if e.local_name().as_ref() == tag => {
-                return handler(XmlElement::new(reader, e, false));
-            }
-            Event::Empty(e) if e.local_name().as_ref() == tag => {
-                return handler(XmlElement::new(reader, e, true));
+            Event::Start(e) => Some((e, false)),
+            Event::Empty(e) => Some((e, true)),
+            Event::End(e) => {
+                return Err(Error::MalformedAttributes(format!(
+                    "Unexpected closing tag </{}> before root element <{}>",
+                    String::from_utf8_lossy(e.local_name().as_ref()),
+                    String::from_utf8_lossy(tag),
+                )));
             }
             Event::Eof => {
-                return Err(Error::PrematureEnd(eof_message.to_string()));
+                return Err(Error::PrematureEnd(format!(
+                    "Document ended before root element <{}> was found",
+                    String::from_utf8_lossy(tag),
+                )));
             }
-            _ => {}
+            _ => None,
+        };
+
+        if let Some((e, empty)) = e {
+            if e.local_name().as_ref() == tag {
+                return handler(XmlElement::new(reader, e, empty));
+            } else {
+                return Err(Error::MalformedAttributes(format!(
+                    "Expected root element <{}>, got <{}>",
+                    String::from_utf8_lossy(tag),
+                    String::from_utf8_lossy(e.local_name().as_ref()),
+                )))
+            }
         }
-        event_buf.clear();
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -311,11 +311,7 @@ pub(crate) struct XmlElement<'a, R: BufRead> {
 }
 
 impl<'a, R: BufRead> XmlElement<'a, R> {
-    pub(crate) fn new(
-        reader: &'a mut Reader<R>,
-        attrs: BytesStart<'a>,
-        is_empty: bool,
-    ) -> Self {
+    pub(crate) fn new(reader: &'a mut Reader<R>, attrs: BytesStart<'a>, is_empty: bool) -> Self {
         Self {
             reader,
             attrs,
@@ -403,7 +399,7 @@ where
                     "Expected root element <{}>, got <{}>",
                     String::from_utf8_lossy(tag),
                     String::from_utf8_lossy(e.local_name().as_ref()),
-                )))
+                )));
             }
         }
     }


### PR DESCRIPTION
Reopening #333

This change switches from `xml-rs` to `quick-xml`, taking care to avoid needless allocations and copying where possible.

Closes #137