### PR TITLE
Add oblique orientation and related map properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Support for `oblique` map orientation.
+- Added the `Oblique` variant to the `Orientation` enum, which is a breaking
+  change for code that matches on it exhaustively.
 - Added `Map` `skew_x` and `skew_y` fields parsed from TMX `skewx`/`skewy`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `oblique` map orientation.
+- Added `Map` `skew_x` and `skew_y` fields parsed from TMX `skewx`/`skewy`.
+
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.
 

--- a/assets/tiled_oblique.tmx
+++ b/assets/tiled_oblique.tmx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.12.0" orientation="oblique" renderorder="right-down" width="4" height="4" tilewidth="32" tileheight="32" infinite="0" skewx="16" skewy="8" nextlayerid="2" nextobjectid="1">
+ <tileset firstgid="1" source="tilesheet.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="4" height="4">
+  <data encoding="csv">
+1,2,3,4,
+5,6,7,8,
+9,10,11,12,
+13,14,15,16
+</data>
+ </layer>
+</map>

--- a/src/map.rs
+++ b/src/map.rs
@@ -171,7 +171,17 @@ impl Map {
         cache: &mut impl ResourceCache,
     ) -> Result<Map> {
         let (
-            (c, infinite, user_type, user_class, skew_x, skew_y, stagger_axis, stagger_index, hex_side_length),
+            (
+                c,
+                infinite,
+                user_type,
+                user_class,
+                skew_x,
+                skew_y,
+                stagger_axis,
+                stagger_index,
+                hex_side_length,
+            ),
             (v, o, w, h, tw, th),
         ) = get_attrs!(
             for v in (elem.attrs) {

--- a/src/map.rs
+++ b/src/map.rs
@@ -54,6 +54,10 @@ pub struct Map {
     /// individual tiles may have different sizes. As such, there is no guarantee that this value
     /// will be the same as the one from the tilesets the map is using.
     pub tile_height: u32,
+    /// The skew x value for oblique maps.
+    pub skew_x: i32,
+    /// The skew y value for oblique maps.
+    pub skew_y: i32,
     /// The length of the side of a hexagonal tile in pixels (used by tile layers on hexagonal maps).
     pub hex_side_length: Option<i32>,
     /// The stagger axis of Hexagonal/Staggered map.
@@ -82,6 +86,9 @@ impl fmt::Debug for Map {
             .field("height", &self.height)
             .field("tile_width", &self.tile_width)
             .field("tile_height", &self.tile_height)
+            .field("skew_x", &self.skew_x)
+            .field("skew_y", &self.skew_y)
+            .field("hex_side_length", &self.hex_side_length)
             .field("stagger_axis", &self.stagger_axis)
             .field("stagger_index", &self.stagger_index)
             .field("tilesets", &format!("{} tilesets", self.tilesets.len()))
@@ -164,7 +171,7 @@ impl Map {
         cache: &mut impl ResourceCache,
     ) -> Result<Map> {
         let (
-            (c, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length),
+            (c, infinite, user_type, user_class, skew_x, skew_y, stagger_axis, stagger_index, hex_side_length),
             (v, o, w, h, tw, th),
         ) = get_attrs!(
             for v in (elem.attrs) {
@@ -172,6 +179,8 @@ impl Map {
                 Some("infinite") => infinite = v == "1",
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
+                Some("skewx") => skew_x ?= v.parse::<i32>(),
+                Some("skewy") => skew_y ?= v.parse::<i32>(),
                 Some("staggeraxis") => stagger_axis ?= v.parse::<StaggerAxis>(),
                 Some("staggerindex") => stagger_index ?= v.parse::<StaggerIndex>(),
                 Some("hexsidelength") => hex_side_length ?= v.parse(),
@@ -182,11 +191,13 @@ impl Map {
                 "tilewidth" => tile_width ?= v.parse::<u32>(),
                 "tileheight" => tile_height ?= v.parse::<u32>(),
             }
-            ((colour, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
+            ((colour, infinite, user_type, user_class, skew_x, skew_y, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
         );
 
         let infinite = infinite.unwrap_or(false);
         let user_type = user_type.or(user_class);
+        let skew_x = skew_x.unwrap_or(0);
+        let skew_y = skew_y.unwrap_or(0);
         let stagger_axis = stagger_axis.unwrap_or_default();
         let stagger_index = stagger_index.unwrap_or_default();
 
@@ -287,6 +298,8 @@ impl Map {
             height: h,
             tile_width: tw,
             tile_height: th,
+            skew_x,
+            skew_y,
             hex_side_length,
             stagger_axis,
             stagger_index,
@@ -388,6 +401,7 @@ pub enum Orientation {
     Isometric,
     Staggered,
     Hexagonal,
+    Oblique,
 }
 
 #[derive(Debug)]
@@ -399,8 +413,8 @@ pub struct OrientationParseError {
 
 impl std::fmt::Display for OrientationParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("failed to parse orientation, valid options are `orthogonal`, `isometric`, `staggered` \
-        and `hexagonal` but got `{}` instead", self.str_found))
+        f.write_fmt(format_args!("failed to parse orientation, valid options are `orthogonal`, `isometric`, `staggered`, \
+        `hexagonal` and `oblique` but got `{}` instead", self.str_found))
     }
 }
 
@@ -415,6 +429,7 @@ impl FromStr for Orientation {
             "isometric" => Ok(Orientation::Isometric),
             "staggered" => Ok(Orientation::Staggered),
             "hexagonal" => Ok(Orientation::Hexagonal),
+            "oblique" => Ok(Orientation::Oblique),
             _ => Err(OrientationParseError {
                 str_found: s.to_owned(),
             }),
@@ -429,6 +444,7 @@ impl fmt::Display for Orientation {
             Orientation::Isometric => write!(f, "isometric"),
             Orientation::Staggered => write!(f, "staggered"),
             Orientation::Hexagonal => write!(f, "hexagonal"),
+            Orientation::Oblique => write!(f, "oblique"),
         }
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -54,9 +54,15 @@ pub struct Map {
     /// individual tiles may have different sizes. As such, there is no guarantee that this value
     /// will be the same as the one from the tilesets the map is using.
     pub tile_height: u32,
-    /// The skew x value for oblique maps.
+    /// The horizontal skew of the tile grid in pixels (used by oblique maps).
+    ///
+    /// Each row of tiles is shifted horizontally by this amount relative to the row above it,
+    /// resulting in a horizontal shear factor of `skew_x / tile_height`.
     pub skew_x: i32,
-    /// The skew y value for oblique maps.
+    /// The vertical skew of the tile grid in pixels (used by oblique maps).
+    ///
+    /// Each column of tiles is shifted vertically by this amount relative to the column to its
+    /// left, resulting in a vertical shear factor of `skew_y / tile_width`.
     pub skew_y: i32,
     /// The length of the side of a hexagonal tile in pixels (used by tile layers on hexagonal maps).
     pub hex_side_length: Option<i32>,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -190,6 +190,17 @@ fn test_just_tileset() {
 }
 
 #[test]
+fn test_oblique_map() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_oblique.tmx")
+        .unwrap();
+
+    assert_eq!(r.orientation, tiled::Orientation::Oblique);
+    assert_eq!(r.skew_x, 16);
+    assert_eq!(r.skew_y, 8);
+}
+
+#[test]
 fn test_infinite_map() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64_zlib_infinite.tmx")

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -19,6 +19,8 @@ fn compare_everything_but_sources(r: &Map, e: &Map) {
     assert_eq!(r.height, e.height);
     assert_eq!(r.tile_width, e.tile_width);
     assert_eq!(r.tile_height, e.tile_height);
+    assert_eq!(r.skew_x, e.skew_x);
+    assert_eq!(r.skew_y, e.skew_y);
     assert_eq!(r.properties, e.properties);
     assert_eq!(r.background_color, e.background_color);
     assert_eq!(r.infinite(), e.infinite());


### PR DESCRIPTION
A feature in the upcoming Tiled 1.12 release, see https://github.com/mapeditor/tiled/pull/4313.