### PR TITLE
Make SFML and GGEZ examples optional features so tests can run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ include = ["src/**/*.rs", "README.md", "LICENSE", "CHANGELOG.md"]
 default = ["zstd"]
 wasm = ["zstd/wasm"]
 world = ["regex", "serde", "serde_json", "serde_regex"]
+sfml-example = ["dep:sfml"]
+ggez-example = ["dep:ggez"]
 
 [lib]
 name = "tiled"
@@ -27,10 +29,12 @@ path = "examples/main.rs"
 [[example]]
 name = "sfml"
 path = "examples/sfml/main.rs"
+required-features = ["sfml-example"]
 
 [[example]]
 name = "ggez"
 path = "examples/ggez/main.rs"
+required-features = ["ggez-example"]
 
 [dependencies]
 base64 = "0.22.1"
@@ -41,10 +45,5 @@ serde = { version = "1.0.216", optional = true }
 serde_json = { version = "1.0.133", optional = true }
 serde_regex = { version = "1.1.0", optional = true }
 regex = { version = "1.11.1", optional = true }
-
-[dev-dependencies.sfml]
-version = "0.21.0"
-features = ["graphics"]
-
-[dev-dependencies.ggez]
-version = "0.9.3"
+sfml = { version = "0.21.0", features = ["graphics"], optional = true }
+ggez = { version = "0.9.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ include = ["src/**/*.rs", "README.md", "LICENSE", "CHANGELOG.md"]
 default = ["zstd"]
 wasm = ["zstd/wasm"]
 world = ["regex", "serde", "serde_json", "serde_regex"]
-sfml-example = ["dep:sfml"]
-ggez-example = ["dep:ggez"]
+example-sfml = ["dep:sfml"]
+example-ggez = ["dep:ggez"]
 
 [lib]
 name = "tiled"
@@ -29,12 +29,12 @@ path = "examples/main.rs"
 [[example]]
 name = "sfml"
 path = "examples/sfml/main.rs"
-required-features = ["sfml-example"]
+required-features = ["example-sfml"]
 
 [[example]]
 name = "ggez"
 path = "examples/ggez/main.rs"
-required-features = ["ggez-example"]
+required-features = ["example-ggez"]
 
 [dependencies]
 base64 = "0.22.1"


### PR DESCRIPTION
# Make SFML and GGEZ examples optional 

Earlier : 
When we use to run tests sfml and ggez compiled as they were dev dependencies and have to be resolved for sure
As a result, running:
`cargo test` attempts to compile native graphics libraries (CSFML).
This fails in headless environments and requires contributors to install graphics libraries even when they only want to use the tiled library.


After :
Making them as a dependency  as  optional and marking them as a feature  the ggez and sfml will only be compiled when features are enabled

Making 2 features each one for them
```rust
[features]
default = ["zstd"]
wasm = ["zstd/wasm"]
world = ["regex", "serde", "serde_json", "serde_regex"]
sfml-example = ["dep:sfml"]
ggez-example = ["dep:ggez"]

```
Making them compile with required features forcing to compile when required

```rust
[[example]]
name = "sfml"
path = "examples/sfml/main.rs"
required-features = ["sfml-example"]

[[example]]
name = "ggez"
path = "examples/ggez/main.rs"
required-features = ["ggez-example"]
```


## After this the test tun without compiling the ggez or sfml libraries

## How to run SFML and GGEZ examples
```bash
cargo run --example --ggez --features=ggez-example
cargo run --example --sfml --features=sfml-example
```
