### PR TITLE
Add support for list properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `Oblique` variant to the `Orientation` enum, which is a breaking
   change for code that matches on it exhaustively.
 - Added `Map` `skew_x` and `skew_y` fields parsed from TMX `skewx`/`skewy`.
+- Added support for list properties via `PropertyValue::ListValue`. (#338, #340, #341)
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 * Thorbjørn Lindeijer
 * Alejandro Perea
 * David Mahany
+* Andrew Minnich

--- a/assets/tiled_object_list_property.tmx
+++ b/assets/tiled_object_list_property.tmx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.12.1" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="5">
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="2" x="0" y="0" width="32" height="32">
+   <properties>
+    <property name="list property" type="list">
+     <item type="object" value="4"/>
+     <item type="object" value="3"/>
+     <item type="bool" value="true"/>
+    </property>
+   </properties>
+  </object>
+  <object id="3" x="32" y="32" width="32" height="32">
+   <properties>
+    <property name="object property" type="object" value="0"/>
+   </properties>
+  </object>
+  <object id="4" x="32" y="0" width="32" height="32">
+   <properties>
+    <property name="object property" type="object" value="0"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/assets/tiled_object_nested_list_property.tmx
+++ b/assets/tiled_object_nested_list_property.tmx
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.12.1" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="5">
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="2" x="0" y="0" width="32" height="32">
+   <properties>
+    <property name="list property" type="list">
+     <item type="object" value="4"/>
+     <item type="object" value="3"/>
+     <item type="bool" value="true"/>
+     <item type="list">
+      <item type="bool" value="false"/>
+      <item type="bool" value="true"/>
+      <item type="list">
+       <item type="bool" value="false"/>
+       <item type="bool" value="true"/>
+      </item>
+     </item>
+     <item type="list">
+      <item type="class" propertytype="ListClass">
+       <properties>
+        <property name="list" type="list">
+         <item type="class" propertytype="Class">
+          <properties>
+           <property name="member_1" value="test"/>
+           <property name="member_2" type="int" value="10"/>
+          </properties>
+         </item>
+        </property>
+       </properties>
+      </item>
+     </item>
+     <item type="int" value="7"/>
+    </property>
+   </properties>
+  </object>
+  <object id="3" x="32" y="32" width="32" height="32">
+   <properties>
+    <property name="object property" type="object" value="0"/>
+   </properties>
+  </object>
+  <object id="4" x="32" y="0" width="32" height="32">
+   <properties>
+    <property name="object property" type="object" value="0"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -80,6 +80,8 @@ pub enum PropertyValue {
     /// An object ID value. Corresponds to the `object` property type.
     /// Holds the id of a referenced object, or 0 if unset.
     ObjectValue(u32),
+    /// A list of property values. Corresponds to the `list` property type.
+    ListValue(Vec<PropertyValue>),
     /// A class value. Corresponds to the `class` property type.
     /// Holds the type name and a set of properties.
     ClassValue {
@@ -150,38 +152,69 @@ pub(crate) fn parse_properties<R: std::io::BufRead>(
                 }
                 (obj_type, value, name, propertytype)
             );
-            let t = t.unwrap_or_else(|| "string".to_owned());
-            if t == "class" {
-                let mut properties = HashMap::new();
-                parse_tag!(elem, {
-                    "properties" => |elem| {
-                        properties = parse_properties(elem)?;
-                        Ok(())
-                    },
-                });
-                p.insert(k, PropertyValue::ClassValue {
-                    property_type: p_t.unwrap_or_default(),
-                    properties,
-                });
-                return Ok(());
-            }
-
-            let v: String = match v_attr {
-                Some(val) => {
-                    parse_tag!(elem, {});
-                    val
-                }
-                None => {
-                    // if the "value" attribute was missing, might be a multiline string
-                    read_text_or_cdata(
-                        elem,
-                        |text| Ok(text.to_string()),
-                    )?
-                }
-            };
-            p.insert(k, PropertyValue::new(t, v)?);
+            p.insert(k, parse_property_value(elem, t, v_attr, p_t)?);
             Ok(())
         },
     });
     Ok(p)
+}
+
+/// Parses the value of a `<property>` or list `<item>` element, given its `type`, `value` and
+/// `propertytype` attributes. Consumes the element's content.
+fn parse_property_value<R: std::io::BufRead>(
+    elem: crate::util::XmlElement<'_, R>,
+    t: Option<String>,
+    v_attr: Option<String>,
+    p_t: Option<String>,
+) -> Result<PropertyValue> {
+    let t = t.unwrap_or_else(|| "string".to_owned());
+    if t == "class" {
+        // Class properties will have their member values stored in a nested <properties>
+        // element. Only the actually set members are saved. When no members have been set
+        // the properties element is left out entirely.
+        let mut properties = HashMap::new();
+        parse_tag!(elem, {
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
+                Ok(())
+            },
+        });
+        return Ok(PropertyValue::ClassValue {
+            property_type: p_t.unwrap_or_default(),
+            properties,
+        });
+    }
+
+    if t == "list" {
+        // List properties store each of their values in a nested <item> element, which is
+        // structured like a <property> element without a name.
+        let mut items = Vec::new();
+        parse_tag!(elem, {
+            "item" => |elem: crate::util::XmlElement<'_, R>| {
+                let (t, v_attr, p_t) = get_attrs!(
+                    for attr in (elem.attrs) {
+                        Some("type") => obj_type = attr.to_string(),
+                        Some("value") => value = attr.to_string(),
+                        Some("propertytype") => propertytype = attr.to_string(),
+                    }
+                    (obj_type, value, propertytype)
+                );
+                items.push(parse_property_value(elem, t, v_attr, p_t)?);
+                Ok(())
+            },
+        });
+        return Ok(PropertyValue::ListValue(items));
+    }
+
+    let v: String = match v_attr {
+        Some(val) => {
+            parse_tag!(elem, {});
+            val
+        }
+        None => {
+            // if the "value" attribute was missing, might be a multiline string
+            read_text_or_cdata(elem, |text| Ok(text.to_string()))?
+        }
+    };
+    PropertyValue::new(t, v)
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use tiled::{
-    Color, FiniteTileLayer, HorizontalAlignment, LayerType, Loader, Map, ObjectShape,
+    Color, FiniteTileLayer, HorizontalAlignment, LayerType, Loader, Map, ObjectShape, Properties,
     PropertyValue, ResourceCache, TileLayer, TilesetLocation, VerticalAlignment, WangId,
 };
 
@@ -458,6 +458,100 @@ fn test_object_property() {
         0
     };
     assert_eq!(3, prop_value);
+}
+
+#[test]
+fn test_object_list_property() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_object_list_property.tmx")
+        .unwrap();
+    let layer = r.get_layer(1).unwrap();
+    let prop_value = if let Some(PropertyValue::ListValue(v)) = layer
+        .as_object_layer()
+        .unwrap()
+        .get_object(0)
+        .unwrap()
+        .properties
+        .get("list property")
+    {
+        v.clone()
+    } else {
+        vec![]
+    };
+    assert_eq!(
+        vec![
+            PropertyValue::ObjectValue(4),
+            PropertyValue::ObjectValue(3),
+            PropertyValue::BoolValue(true),
+        ],
+        prop_value
+    );
+}
+
+#[test]
+fn test_object_nested_list_property() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_object_nested_list_property.tmx")
+        .unwrap();
+    let layer = r.get_layer(1).unwrap();
+    let objects = layer.as_object_layer().unwrap();
+    let prop_value = if let Some(PropertyValue::ListValue(v)) = objects
+        .get_object(0)
+        .unwrap()
+        .properties
+        .get("list property")
+    {
+        v.clone()
+    } else {
+        vec![]
+    };
+    assert_eq!(
+        vec![
+            PropertyValue::ObjectValue(4),
+            PropertyValue::ObjectValue(3),
+            PropertyValue::BoolValue(true),
+            PropertyValue::ListValue(vec![
+                PropertyValue::BoolValue(false),
+                PropertyValue::BoolValue(true),
+                PropertyValue::ListValue(vec![
+                    PropertyValue::BoolValue(false),
+                    PropertyValue::BoolValue(true),
+                ])
+            ]),
+            PropertyValue::ListValue(vec![PropertyValue::ClassValue {
+                property_type: "ListClass".to_string(),
+                properties: Properties::from([(
+                    "list".to_string(),
+                    PropertyValue::ListValue(vec![PropertyValue::ClassValue {
+                        property_type: "Class".to_string(),
+                        properties: Properties::from([
+                            (
+                                "member_1".to_string(),
+                                PropertyValue::StringValue("test".to_string())
+                            ),
+                            ("member_2".to_string(), PropertyValue::IntValue(10))
+                        ])
+                    }])
+                ),])
+            }]),
+            PropertyValue::IntValue(7),
+        ],
+        prop_value
+    );
+
+    // The properties of the objects following the nested list must be unaffected by its parsing.
+    for index in 1..=2 {
+        assert_eq!(
+            objects
+                .get_object(index)
+                .unwrap()
+                .properties
+                .get("object property"),
+            Some(&PropertyValue::ObjectValue(0)),
+            "property of object {} was corrupted by list parsing",
+            index
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Adds support for the list property type introduced in Tiled 1.12, as a new `PropertyValue::ListValue(Vec<PropertyValue>)` variant.

This is a port of #338 by @tesselode and #340 by @AwfulToTheEar to the `next` branch, which has since switched to quick-xml (#334). Both authors are credited via Co-authored-by.

Compared to #340:
- Since the quick-xml parser scopes each element's parsing to an `XmlElement`, nested lists are handled by plain recursion; the `parse_tag_with_depth` macro and depth tracking are no longer needed.
- The nested list test asset gained a scalar item following the nested lists, and the test asserts that the objects following the list-carrying object still parse correctly. This encodes the nesting regression that #340 fixed over #338, where sibling items were swallowed into a nested list and parsing of subsequent elements was corrupted.