### PR TITLE
Add layer blend mode, capsule shape and object opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for list properties via `PropertyValue::ListValue`. (#338, #340, #341)
 - Added `Tileset` `tile_render_size`, `fill_mode` and `object_alignment` fields parsed from
   the TMX `tilerendersize`, `fillmode` and `objectalignment` attributes.
+- Added the `Capsule` variant to the `ObjectShape` enum, which is a breaking change for
+  code that matches on it exhaustively.
+- Added `LayerData` `blend_mode` field parsed from the TMX `mode` attribute.
+- Added `ObjectData` `opacity` field parsed from the TMX `opacity` attribute.
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.

--- a/assets/tiled_object_capsule.tmx
+++ b/assets/tiled_object_capsule.tmx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.12.0" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="3">
+ <layer id="1" name="Tile Layer 1" width="2" height="2" mode="multiply">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1" mode="add">
+  <object id="1" x="8" y="8" width="16" height="48" opacity="0.5">
+   <capsule/>
+  </object>
+  <object id="2" x="32" y="0" width="32" height="32"/>
+ </objectgroup>
+</map>

--- a/examples/ggez/main.rs
+++ b/examples/ggez/main.rs
@@ -44,9 +44,15 @@ struct Game {
 
 impl Game {
     fn new(ctx: &mut ggez::Context) -> GameResult<Self> {
+        // The map to load can be given as an argument, and is resolved relative to the
+        // repository's `/assets` directory
+        let map_path = std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| "/tiled_base64_external.tmx".to_string());
+
         // Load the map, using a loader with `GgezResourceReader` for reading from the ggez filesystem
         let mut loader = tiled::Loader::with_reader(GgezResourceReader(&mut ctx.fs));
-        let map = loader.load_tmx_map("/tiled_base64_external.tmx").unwrap();
+        let map = loader.load_tmx_map(map_path).unwrap();
 
         let map_handler = MapHandler::new(map, ctx).unwrap();
 

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -258,6 +258,17 @@ impl MapHandler {
                 )?;
                 canvas.draw(&shape, draw_param);
             }
+            tiled::ObjectShape::Capsule { width, height } => {
+                let bounds = graphics::Rect::new(object.x, object.y, *width, *height);
+                let shape = graphics::Mesh::new_rounded_rectangle(
+                    ctx,
+                    graphics::DrawMode::stroke(2.0),
+                    bounds,
+                    width.min(*height) / 2.0,
+                    graphics::Color::CYAN,
+                )?;
+                canvas.draw(&shape, draw_param);
+            }
             tiled::ObjectShape::Polyline { points } => {
                 let points: Vec<_> = points
                     .iter()

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -48,6 +48,10 @@ pub struct LayerData {
     pub parallax_y: f32,
     /// The layer's opacity.
     pub opacity: f32,
+    /// The blend mode to use when rendering this layer, `normal` by default. Other values
+    /// written by Tiled are `add`, `multiply`, `screen`, `overlay`, `darken`, `lighten`,
+    /// `color-dodge`, `color-burn`, `hard-light`, `soft-light`, `difference` and `exclusion`.
+    pub blend_mode: String,
     /// The layer's tint color.
     pub tint_color: Option<Color>,
     /// The layer's custom properties, as arbitrarily set by the user.
@@ -77,6 +81,7 @@ impl LayerData {
     ) -> Result<Self> {
         let (
             opacity,
+            blend_mode,
             tint_color,
             visible,
             offset_x,
@@ -90,6 +95,7 @@ impl LayerData {
         ) = get_attrs!(
             for v in (elem.attrs) {
                 Some("opacity") => opacity ?= v.parse(),
+                Some("mode") => blend_mode = v.to_string(),
                 Some("tintcolor") => tint_color ?= v.parse(),
                 Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
                 Some("offsetx") => offset_x ?= v.parse(),
@@ -101,7 +107,7 @@ impl LayerData {
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
             }
-            (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type, user_class)
+            (opacity, blend_mode, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type, user_class)
         );
 
         let (ty, properties) = match tag {
@@ -145,6 +151,7 @@ impl LayerData {
             parallax_x: parallax_x.unwrap_or(1.0),
             parallax_y: parallax_y.unwrap_or(1.0),
             opacity: opacity.unwrap_or(1.0),
+            blend_mode: blend_mode.unwrap_or_else(|| "normal".to_string()),
             tint_color,
             name: name.unwrap_or_default(),
             id: id.unwrap_or(0),

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -126,6 +126,10 @@ pub enum ObjectShape {
         width: f32,
         height: f32,
     },
+    Capsule {
+        width: f32,
+        height: f32,
+    },
     Polyline {
         points: Vec<(f32, f32)>,
     },
@@ -190,6 +194,8 @@ pub struct ObjectData {
     pub y: f32,
     /// The clockwise rotation of this object around (x,y) in degrees.
     pub rotation: f32,
+    /// The opacity of this object.
+    pub opacity: f32,
     /// Whether the object is shown or hidden.
     pub visible: bool,
     /// The object's shape.
@@ -226,7 +232,7 @@ impl ObjectData {
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<ObjectData> {
-        let (id, tile, mut n, mut t, c, mut w, mut h, mut v, mut r, template, x, y) = get_attrs!(
+        let (id, tile, mut n, mut t, c, mut w, mut h, mut v, mut r, mut o, template, x, y) = get_attrs!(
             for v in (elem.attrs) {
                 Some("id") => id ?= v.parse(),
                 Some("gid") => tile ?= v.parse::<u32>(),
@@ -237,11 +243,12 @@ impl ObjectData {
                 Some("height") => height ?= v.parse(),
                 Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
                 Some("rotation") => rotation ?= v.parse(),
+                Some("opacity") => opacity ?= v.parse(),
                 Some("template") => template ?= v.parse(),
                 Some("x") => x ?= v.parse::<f32>(),
                 Some("y") => y ?= v.parse::<f32>(),
             }
-            (id, tile, name, user_type, user_class, width, height, visible, rotation, template, x, y)
+            (id, tile, name, user_type, user_class, width, height, visible, rotation, opacity, template, x, y)
         );
         let x = x.unwrap_or(0.);
         let y = y.unwrap_or(0.);
@@ -267,6 +274,7 @@ impl ObjectData {
                 let obj = &template.object;
                 v.get_or_insert(obj.visible);
                 r.get_or_insert(obj.rotation);
+                o.get_or_insert(obj.opacity);
                 n.get_or_insert_with(|| obj.name.clone());
                 t.get_or_insert_with(|| obj.user_type.clone());
                 if let Some(templ_tile) = &obj.tile {
@@ -275,6 +283,7 @@ impl ObjectData {
                 match &obj.shape {
                     ObjectShape::Rect { width, height }
                     | ObjectShape::Ellipse { width, height }
+                    | ObjectShape::Capsule { width, height }
                     | ObjectShape::Text { width, height, .. } => {
                         w.get_or_insert(*width);
                         h.get_or_insert(*height);
@@ -289,6 +298,7 @@ impl ObjectData {
         let width = w.unwrap_or(0f32);
         let height = h.unwrap_or(0f32);
         let rotation = r.unwrap_or(0f32);
+        let opacity = o.unwrap_or(1f32);
         let id = id.unwrap_or(0u32);
         let name = n.unwrap_or_default();
         let user_type: String = t.or(c).unwrap_or_default();
@@ -298,6 +308,14 @@ impl ObjectData {
         parse_tag!(elem, {
             "ellipse" => |elem: crate::util::XmlElement<'_, R>| {
                 shape = Some(ObjectShape::Ellipse {
+                    width,
+                    height,
+                });
+                parse_tag!(elem, {});
+                Ok(())
+            },
+            "capsule" => |elem: crate::util::XmlElement<'_, R>| {
+                shape = Some(ObjectShape::Capsule {
                     width,
                     height,
                 });
@@ -334,6 +352,7 @@ impl ObjectData {
                 match &templ.object.shape {
                     ObjectShape::Rect { .. } => ObjectShape::Rect { width, height },
                     ObjectShape::Ellipse { .. } => ObjectShape::Ellipse { width, height },
+                    ObjectShape::Capsule { .. } => ObjectShape::Capsule { width, height },
                     ObjectShape::Point(_, _) => ObjectShape::Point(x, y),
                     ObjectShape::Text {
                         font_family,
@@ -389,6 +408,7 @@ impl ObjectData {
             x,
             y,
             rotation,
+            opacity,
             visible,
             shape,
             properties,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -459,6 +459,32 @@ fn test_repeat() {
 }
 
 #[test]
+fn test_capsule_object_and_blend_modes() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_object_capsule.tmx")
+        .unwrap();
+
+    assert_eq!(r.get_layer(0).unwrap().blend_mode, "multiply");
+
+    let layer = r.get_layer(1).unwrap();
+    assert_eq!(layer.blend_mode, "add");
+
+    let objects = layer.as_object_layer().unwrap();
+    let capsule = objects.get_object(0).unwrap();
+    assert_eq!(
+        capsule.shape,
+        ObjectShape::Capsule {
+            width: 16.0,
+            height: 48.0
+        }
+    );
+    assert_eq!(capsule.opacity, 0.5);
+
+    // An object without an opacity attribute gets the default value.
+    assert_eq!(objects.get_object(1).unwrap().opacity, 1.0);
+}
+
+#[test]
 fn test_object_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_object_property.tmx")


### PR DESCRIPTION
Completes support for the format additions in Tiled 1.12 (with oblique orientation and list properties already merged):

- **Layer blend mode**: `LayerData::blend_mode`, parsed from the `mode` attribute on all layer types. Stored as a plain `String` defaulting to `normal` rather than an enum, so that future blend modes won't fail parsing, matching Tiled's own lenient reading. The doc comment lists the values Tiled currently writes.
- **Capsule object shape**: `ObjectShape::Capsule { width, height }`, parsed from the `<capsule/>` child element. Handled in template inheritance like the other sized shapes. Note: a new variant on `ObjectShape` is a breaking change for exhaustive matches (noted in the changelog).
- **Object opacity**: `ObjectData::opacity`, parsed from the `opacity` attribute, defaulting to 1.0 and inherited from templates like visibility and rotation.

Includes a test asset exercising all three (capsule with non-default opacity, blend modes on both a tile layer and an object layer) plus default-value assertions.