### PR TITLE
Add remaining pre-1.12 TMX format attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code that matches on it exhaustively.
 - Added `LayerData` `blend_mode` field parsed from the TMX `mode` attribute.
 - Added `ObjectData` `opacity` field parsed from the TMX `opacity` attribute.
+- Added `Map` `render_order`, `parallax_origin_x` and `parallax_origin_y` fields parsed from
+  the TMX `renderorder`, `parallaxoriginx` and `parallaxoriginy` attributes.
+- Added `ObjectLayerData` `draw_order` field parsed from the TMX `draworder` attribute.
+- Added `Tileset` `transformations` field parsed from the TMX `transformations` element.
+- Added `WangSet` and `WangColor` `user_type` fields parsed from the TMX `class` attribute.
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.

--- a/assets/tiled_object_capsule.tmx
+++ b/assets/tiled_object_capsule.tmx
@@ -6,7 +6,7 @@
 0,0
 </data>
  </layer>
- <objectgroup id="2" name="Object Layer 1" mode="add">
+ <objectgroup id="2" name="Object Layer 1" mode="add" draworder="index">
   <object id="1" x="8" y="8" width="16" height="48" opacity="0.5">
    <capsule/>
   </object>

--- a/assets/tiled_parallax.tmx
+++ b/assets/tiled_parallax.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="4" nextobjectid="1">
+<map version="1.5" tiledversion="1.7.1" orientation="orthogonal" renderorder="right-up" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" parallaxoriginx="120" parallaxoriginy="-40.5" nextlayerid="4" nextobjectid="1">
  <tileset firstgid="1" source="tilesheet.tsx"/>
  <layer id="3" name="Background" width="10" height="10" parallaxx="0.5" parallaxy="0.75">
   <data encoding="csv">

--- a/assets/tilesheet_wangsets.tsx
+++ b/assets/tilesheet_wangsets.tsx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tileset version="1.8" tiledversion="1.8.5" name="tilesheet_wangsets" tilewidth="32" tileheight="32" tilecount="84" columns="14">
  <image source="tilesheet.png" width="448" height="192"/>
+ <transformations hflip="1" vflip="1" rotate="0" preferuntransformed="1"/>
  <wangsets>
-  <wangset name="Void" type="mixed" tile="-1">
-   <wangcolor name="" color="#ff0000" tile="-1" probability="1"/>
+  <wangset name="Void" type="mixed" tile="-1" class="VoidSet">
+   <wangcolor name="" color="#ff0000" tile="-1" probability="1" class="VoidColor"/>
    <wangtile tileid="0" wangid="1,1,0,0,0,0,0,1"/>
    <wangtile tileid="1" wangid="0,0,0,1,1,1,0,0"/>
    <wangtile tileid="14" wangid="0,0,0,0,0,1,1,1"/>

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -7,12 +7,64 @@ use crate::{
     Tileset,
 };
 
+/// The order in which the objects of an object layer are drawn.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub enum DrawOrder {
+    /// The objects are drawn sorted by their y-coordinate.
+    #[default]
+    TopDown,
+    /// The objects are drawn in the order of appearance in the map file, which can be manually
+    /// arranged in the editor.
+    Index,
+}
+
+#[derive(Debug)]
+/// An error arising from trying to parse a [`DrawOrder`] that is not valid.
+pub struct DrawOrderParseError {
+    /// The invalid string found.
+    pub str_found: String,
+}
+
+impl std::fmt::Display for DrawOrderParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "failed to parse draw order, valid options are `topdown` and `index` \
+        but got `{}` instead",
+            self.str_found
+        ))
+    }
+}
+
+impl std::str::FromStr for DrawOrder {
+    type Err = DrawOrderParseError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "topdown" => Ok(DrawOrder::TopDown),
+            "index" => Ok(DrawOrder::Index),
+            _ => Err(DrawOrderParseError {
+                str_found: s.to_owned(),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for DrawOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DrawOrder::TopDown => write!(f, "topdown"),
+            DrawOrder::Index => write!(f, "index"),
+        }
+    }
+}
+
 /// Raw data referring to a map object layer or tile collision data.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ObjectLayerData {
     objects: Vec<ObjectData>,
     /// The color used in the editor to display objects in this layer.
     pub colour: Option<Color>,
+    /// The order in which the objects in this layer are drawn.
+    pub draw_order: DrawOrder,
 }
 
 impl ObjectLayerData {
@@ -27,12 +79,14 @@ impl ObjectLayerData {
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<(ObjectLayerData, Properties)> {
-        let c = get_attrs!(
+        let (c, draw_order) = get_attrs!(
             for v in (elem.attrs) {
                 Some("color") => color ?= v.parse(),
+                Some("draworder") => draw_order ?= v.parse::<DrawOrder>(),
             }
-            color
+            (color, draw_order)
         );
+        let draw_order = draw_order.unwrap_or_default();
         let mut objects = Vec::new();
         let mut properties = HashMap::new();
         parse_tag!(elem, {
@@ -45,7 +99,14 @@ impl ObjectLayerData {
                 Ok(())
             },
         });
-        Ok((ObjectLayerData { objects, colour: c }, properties))
+        Ok((
+            ObjectLayerData {
+                objects,
+                colour: c,
+                draw_order,
+            },
+            properties,
+        ))
     }
 
     /// Returns the data belonging to the objects contained within the layer, in the order they were

--- a/src/map.rs
+++ b/src/map.rs
@@ -30,6 +30,9 @@ pub struct Map {
     pub source: PathBuf,
     /// The way tiles are laid out in the map.
     pub orientation: Orientation,
+    /// The order in which the tiles of tile layers are rendered (only relevant for orthogonal
+    /// maps).
+    pub render_order: RenderOrder,
     /// Width of the map, in tiles.
     ///
     /// ## Note
@@ -64,6 +67,12 @@ pub struct Map {
     /// Each column of tiles is shifted vertically by this amount relative to the column to its
     /// left, resulting in a vertical shear factor of `skew_y / tile_width`.
     pub skew_y: i32,
+    /// The X coordinate of the parallax origin in pixels, relative to which all layers are
+    /// scrolled by their parallax factor.
+    pub parallax_origin_x: f32,
+    /// The Y coordinate of the parallax origin in pixels, relative to which all layers are
+    /// scrolled by their parallax factor.
+    pub parallax_origin_y: f32,
     /// The length of the side of a hexagonal tile in pixels (used by tile layers on hexagonal maps).
     pub hex_side_length: Option<i32>,
     /// The stagger axis of Hexagonal/Staggered map.
@@ -88,12 +97,15 @@ impl fmt::Debug for Map {
         f.debug_struct("Map")
             .field("version", &self.version)
             .field("orientation", &self.orientation)
+            .field("render_order", &self.render_order)
             .field("width", &self.width)
             .field("height", &self.height)
             .field("tile_width", &self.tile_width)
             .field("tile_height", &self.tile_height)
             .field("skew_x", &self.skew_x)
             .field("skew_y", &self.skew_y)
+            .field("parallax_origin_x", &self.parallax_origin_x)
+            .field("parallax_origin_y", &self.parallax_origin_y)
             .field("hex_side_length", &self.hex_side_length)
             .field("stagger_axis", &self.stagger_axis)
             .field("stagger_index", &self.stagger_index)
@@ -182,8 +194,11 @@ impl Map {
                 infinite,
                 user_type,
                 user_class,
+                render_order,
                 skew_x,
                 skew_y,
+                parallax_origin_x,
+                parallax_origin_y,
                 stagger_axis,
                 stagger_index,
                 hex_side_length,
@@ -195,8 +210,11 @@ impl Map {
                 Some("infinite") => infinite = v == "1",
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
+                Some("renderorder") => render_order ?= v.parse::<RenderOrder>(),
                 Some("skewx") => skew_x ?= v.parse::<i32>(),
                 Some("skewy") => skew_y ?= v.parse::<i32>(),
+                Some("parallaxoriginx") => parallax_origin_x ?= v.parse::<f32>(),
+                Some("parallaxoriginy") => parallax_origin_y ?= v.parse::<f32>(),
                 Some("staggeraxis") => stagger_axis ?= v.parse::<StaggerAxis>(),
                 Some("staggerindex") => stagger_index ?= v.parse::<StaggerIndex>(),
                 Some("hexsidelength") => hex_side_length ?= v.parse(),
@@ -207,13 +225,16 @@ impl Map {
                 "tilewidth" => tile_width ?= v.parse::<u32>(),
                 "tileheight" => tile_height ?= v.parse::<u32>(),
             }
-            ((colour, infinite, user_type, user_class, skew_x, skew_y, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
+            ((colour, infinite, user_type, user_class, render_order, skew_x, skew_y, parallax_origin_x, parallax_origin_y, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
         );
 
         let infinite = infinite.unwrap_or(false);
         let user_type = user_type.or(user_class);
+        let render_order = render_order.unwrap_or_default();
         let skew_x = skew_x.unwrap_or(0);
         let skew_y = skew_y.unwrap_or(0);
+        let parallax_origin_x = parallax_origin_x.unwrap_or(0.0);
+        let parallax_origin_y = parallax_origin_y.unwrap_or(0.0);
         let stagger_axis = stagger_axis.unwrap_or_default();
         let stagger_index = stagger_index.unwrap_or_default();
 
@@ -310,12 +331,15 @@ impl Map {
             version: v,
             source: map_path.to_owned(),
             orientation: o,
+            render_order,
             width: w,
             height: h,
             tile_width: tw,
             tile_height: th,
             skew_x,
             skew_y,
+            parallax_origin_x,
+            parallax_origin_y,
             hex_side_length,
             stagger_axis,
             stagger_index,
@@ -405,6 +429,61 @@ impl FromStr for StaggerAxis {
             _ => Err(StaggerAxisError {
                 str_found: s.to_owned(),
             }),
+        }
+    }
+}
+
+/// The order in which the tiles of tile layers are rendered. In all cases, the map is drawn
+/// row-by-row. Only relevant for orthogonal maps.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+#[allow(missing_docs)]
+pub enum RenderOrder {
+    #[default]
+    RightDown,
+    RightUp,
+    LeftDown,
+    LeftUp,
+}
+
+#[derive(Debug)]
+/// An error arising from trying to parse a [`RenderOrder`] that is not valid.
+pub struct RenderOrderParseError {
+    /// The invalid string found.
+    pub str_found: String,
+}
+
+impl std::fmt::Display for RenderOrderParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "failed to parse render order, valid options are `right-down`, `right-up`, \
+        `left-down` and `left-up` but got `{}` instead",
+            self.str_found
+        ))
+    }
+}
+
+impl FromStr for RenderOrder {
+    type Err = RenderOrderParseError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "right-down" => Ok(RenderOrder::RightDown),
+            "right-up" => Ok(RenderOrder::RightUp),
+            "left-down" => Ok(RenderOrder::LeftDown),
+            "left-up" => Ok(RenderOrder::LeftUp),
+            _ => Err(RenderOrderParseError {
+                str_found: s.to_owned(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for RenderOrder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenderOrder::RightDown => write!(f, "right-down"),
+            RenderOrder::RightUp => write!(f, "right-up"),
+            RenderOrder::LeftDown => write!(f, "left-down"),
+            RenderOrder::LeftUp => write!(f, "left-up"),
         }
     }
 }

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -60,6 +60,9 @@ pub struct Tileset {
     pub fill_mode: FillMode,
     /// The alignment to use for tile objects referring to tiles of this tileset.
     pub object_alignment: ObjectAlignment,
+    /// The transformations that can be applied to the tiles of this tileset, for example when
+    /// used by Wang sets.
+    pub transformations: Transformations,
 
     /// A tileset can either:
     /// * have a single spritesheet `image` in `tileset` ("regular" tileset);
@@ -81,6 +84,21 @@ pub struct Tileset {
 
     /// The custom tileset type, arbitrarily set by the user.
     pub user_type: Option<String>,
+}
+
+/// The transformations that can be applied to the tiles of a tileset, for example when used by
+/// Wang sets.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub struct Transformations {
+    /// Whether the tiles in this tileset can be flipped horizontally.
+    pub hflip: bool,
+    /// Whether the tiles in this tileset can be flipped vertically.
+    pub vflip: bool,
+    /// Whether the tiles in this tileset can be rotated in 90-degree increments.
+    pub rotate: bool,
+    /// Whether untransformed tiles remain preferred, otherwise transformed tiles are used to
+    /// produce more variations.
+    pub prefer_untransformed: bool,
 }
 
 /// The size to use when rendering a tileset's tiles on a tile layer.
@@ -465,6 +483,7 @@ impl Tileset {
         let mut properties = HashMap::new();
         let mut wang_sets = Vec::new();
         let mut offset = (0i32, 0i32);
+        let mut transformations = Transformations::default();
 
         parse_tag!(elem, {
             "image" => |elem| {
@@ -473,6 +492,10 @@ impl Tileset {
             },
             "tileoffset" => |elem| {
                 offset = parse_tileoffset(elem)?;
+                Ok(())
+            },
+            "transformations" => |elem| {
+                transformations = parse_transformations(elem)?;
                 Ok(())
             },
             "properties" => |elem| {
@@ -532,6 +555,7 @@ impl Tileset {
             tile_render_size: prop.tile_render_size.unwrap_or_default(),
             fill_mode: prop.fill_mode.unwrap_or_default(),
             object_alignment: prop.object_alignment.unwrap_or_default(),
+            transformations,
             tilecount: prop.tilecount,
             image,
             tiles,
@@ -555,6 +579,28 @@ impl Tileset {
                 )
             })
     }
+}
+
+/// Parse the optional <transformations hflip=... vflip=... rotate=... preferuntransformed=.../> tag.
+fn parse_transformations<R: std::io::BufRead>(
+    elem: crate::util::XmlElement<'_, R>,
+) -> Result<Transformations> {
+    let (hflip, vflip, rotate, prefer_untransformed) = get_attrs!(
+        for v in (elem.attrs) {
+            Some("hflip") => hflip = v == "1",
+            Some("vflip") => vflip = v == "1",
+            Some("rotate") => rotate = v == "1",
+            Some("preferuntransformed") => prefer_untransformed = v == "1",
+        }
+        (hflip, vflip, rotate, prefer_untransformed)
+    );
+    parse_tag!(elem, {});
+    Ok(Transformations {
+        hflip: hflip.unwrap_or(false),
+        vflip: vflip.unwrap_or(false),
+        rotate: rotate.unwrap_or(false),
+        prefer_untransformed: prefer_untransformed.unwrap_or(false),
+    })
 }
 
 /// Parse the optional <tileoffset x=... y=.../> tag.

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -31,6 +31,8 @@ impl Default for WangSetType {
 pub struct WangSet {
     /// The name of the Wang set.
     pub name: String,
+    /// The custom type of the Wang set, arbitrarily set by the user.
+    pub user_type: Option<String>,
     /// Type of Wang set.
     pub wang_set_type: WangSetType,
     /// The tile ID of the tile representing this Wang set.
@@ -49,13 +51,14 @@ impl WangSet {
         elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangSet> {
         // Get common data
-        let (name, wang_set_type, tile) = get_attrs!(
+        let ((user_type,), (name, wang_set_type, tile)) = get_attrs!(
             for v in (elem.attrs) {
+                Some("class") => user_type ?= v.parse::<String>(),
                 "name" => name ?= v.parse::<String>(),
                 "type" => wang_set_type ?= v.parse::<String>(),
                 "tile" => tile ?= v.parse::<i64>(),
             }
-            (name, wang_set_type, tile)
+            ((user_type,), (name, wang_set_type, tile))
         );
 
         let wang_set_type = match wang_set_type.as_str() {
@@ -88,6 +91,7 @@ impl WangSet {
 
         Ok(WangSet {
             name,
+            user_type,
             wang_set_type,
             tile,
             wang_colors,

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -11,6 +11,8 @@ use crate::{
 pub struct WangColor {
     /// The name of this color.
     pub name: String,
+    /// The custom type of this color, arbitrarily set by the user.
+    pub user_type: Option<String>,
     #[allow(missing_docs)]
     pub color: Color,
     /// The tile ID of the tile representing this color.
@@ -27,14 +29,15 @@ impl WangColor {
         elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangColor> {
         // Get common data
-        let (name, color, tile, probability) = get_attrs!(
+        let ((user_type,), (name, color, tile, probability)) = get_attrs!(
             for v in (elem.attrs) {
+                Some("class") => user_type ?= v.parse::<String>(),
                 "name" => name ?= v.parse::<String>(),
                 "color" => color ?= v.parse(),
                 "tile" => tile ?= v.parse::<i64>(),
                 "probability" => probability ?= v.parse::<f32>(),
             }
-            (name, color, tile, probability)
+            ((user_type,), (name, color, tile, probability))
         );
 
         let tile = if tile >= 0 { Some(tile as u32) } else { None };
@@ -50,6 +53,7 @@ impl WangColor {
 
         Ok(WangColor {
             name,
+            user_type,
             color,
             tile,
             probability,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -406,6 +406,9 @@ fn test_parallax_layers() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_parallax.tmx")
         .unwrap();
+    assert_eq!(r.render_order, tiled::RenderOrder::RightUp);
+    assert_eq!(r.parallax_origin_x, 120.0);
+    assert_eq!(r.parallax_origin_y, -40.5);
     for (i, layer) in r.layers().enumerate() {
         match i {
             0 => {
@@ -470,6 +473,8 @@ fn test_capsule_object_and_blend_modes() {
     assert_eq!(layer.blend_mode, "add");
 
     let objects = layer.as_object_layer().unwrap();
+    assert_eq!(objects.draw_order, tiled::DrawOrder::Index);
+
     let capsule = objects.get_object(0).unwrap();
     assert_eq!(
         capsule.shape,
@@ -489,6 +494,15 @@ fn test_object_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_object_property.tmx")
         .unwrap();
+    // An object layer without a draworder attribute gets the default value.
+    assert_eq!(
+        r.get_layer(1)
+            .unwrap()
+            .as_object_layer()
+            .unwrap()
+            .draw_order,
+        tiled::DrawOrder::TopDown
+    );
     let layer = r.get_layer(1).unwrap();
     let prop_value = if let Some(PropertyValue::ObjectValue(v)) = layer
         .as_object_layer()
@@ -795,7 +809,22 @@ fn test_reading_wang_sets() {
 
     // We will pick some random data from the wangsets for tessting
     let tileset = map.tilesets().get(0).unwrap();
+    assert_eq!(
+        tileset.transformations,
+        tiled::Transformations {
+            hflip: true,
+            vflip: true,
+            rotate: false,
+            prefer_untransformed: true,
+        }
+    );
     assert_eq!(tileset.wang_sets.len(), 3);
+    let wangset_1 = tileset.wang_sets.get(0).unwrap();
+    assert_eq!(wangset_1.user_type.as_deref(), Some("VoidSet"));
+    assert_eq!(
+        wangset_1.wang_colors[0].user_type.as_deref(),
+        Some("VoidColor")
+    );
     let wangset_2 = tileset.wang_sets.get(1).unwrap();
     let tile_10 = wangset_2.wang_tiles.get(&10).unwrap();
     assert_eq!(tile_10.wang_id, WangId([2u8, 2, 0, 2, 0, 2, 2, 2]));


### PR DESCRIPTION
Fills in the older TMX format features that were still unsupported, completing format coverage up to Tiled 1.12 together with #335, #341, #342 and #343:

- **`Map::render_order`** (`renderorder`, Tiled 0.10): new `RenderOrder` enum (`right-down` default, `right-up`, `left-down`, `left-up`), following the existing enum pattern.
- **`ObjectLayerData::draw_order`** (`draworder`, Tiled 0.10): new `DrawOrder` enum (`topdown` default, `index`).
- **`Tileset::transformations`** (`<transformations>` element, Tiled 1.5): a `Transformations` struct with `hflip`, `vflip`, `rotate` and `prefer_untransformed` flags, all-false when the element is absent (matching Tiled, which omits it when no flags are set).
- **`Map::parallax_origin_x`/`parallax_origin_y`** (`parallaxoriginx`/`parallaxoriginy`, Tiled 1.8), defaulting to 0.
- **`WangSet::user_type` and `WangColor::user_type`** (`class`, Tiled 1.9): the last elements missing user class support.

Tests piggyback on the thematically matching existing assets: `tiled_parallax.tmx` gained a render order and parallax origin, `tiled_object_capsule.tmx` an index draw order, and `tilesheet_wangsets.tsx` a transformations element and class attributes, with default-value assertions covering unmodified assets.