### PR TITLE
Unify user_type fields on a plain String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.
+- The `user_type` fields on `Map`, `Tileset`, `LayerData` and `TileData` changed from
+  `Option<String>` to `String`, which is empty when the `class` attribute is not set. This
+  matches `ObjectData` as well as Tiled itself.
 
 ## [0.15.1]
 ### Changed

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -57,7 +57,7 @@ pub struct LayerData {
     /// The layer's custom properties, as arbitrarily set by the user.
     pub properties: Properties,
     /// The layer's type, which is arbitrarily setby the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
     layer_type: LayerDataType,
 }
 
@@ -155,7 +155,7 @@ impl LayerData {
             tint_color,
             name: name.unwrap_or_default(),
             id: id.unwrap_or(0),
-            user_type: user_type.or(user_class),
+            user_type: user_type.or(user_class).unwrap_or_default(),
             properties,
             layer_type: ty,
         })

--- a/src/map.rs
+++ b/src/map.rs
@@ -89,7 +89,7 @@ pub struct Map {
     pub background_color: Option<Color>,
     infinite: bool,
     /// The type of the map, which is arbitrary and set by the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
 }
 
 impl fmt::Debug for Map {
@@ -229,7 +229,7 @@ impl Map {
         );
 
         let infinite = infinite.unwrap_or(false);
-        let user_type = user_type.or(user_class);
+        let user_type = user_type.or(user_class).unwrap_or_default();
         let render_order = render_order.unwrap_or_default();
         let skew_x = skew_x.unwrap_or(0);
         let skew_y = skew_y.unwrap_or(0);

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -38,7 +38,7 @@ pub struct TileData {
     /// The animation frames of this tile.
     pub animation: Option<Vec<Frame>>,
     /// The type of this tile.
-    pub user_type: Option<String>,
+    pub user_type: String,
     /// The probability of this tile.
     pub probability: f32,
     /// The image rect of this tile, which is only used in image collection tilesets and corresponds
@@ -94,7 +94,7 @@ impl TileData {
             ((user_type, user_class, probability, x, y, width, height), id)
         );
 
-        let user_type = user_type.or(user_class);
+        let user_type = user_type.or(user_class).unwrap_or_default();
         let mut image = Option::None;
         let mut properties = HashMap::new();
         let mut objectgroup = None;

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -83,7 +83,7 @@ pub struct Tileset {
     pub properties: Properties,
 
     /// The custom tileset type, arbitrarily set by the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
 }
 
 /// The transformations that can be applied to the tiles of a tileset, for example when used by
@@ -296,7 +296,7 @@ struct TilesetProperties {
     tilecount: u32,
     columns: Option<u32>,
     name: String,
-    user_type: Option<String>,
+    user_type: String,
     tile_width: u32,
     tile_height: u32,
     tile_render_size: Option<TileRenderSize>,
@@ -379,7 +379,7 @@ impl Tileset {
                 spacing,
                 margin,
                 name: name.unwrap_or_default(),
-                user_type: user_type.or(user_class),
+                user_type: user_type.or(user_class).unwrap_or_default(),
                 root_path,
                 columns,
                 tilecount,
@@ -456,7 +456,7 @@ impl Tileset {
                 spacing,
                 margin,
                 name: name.unwrap_or_default(),
-                user_type: user_type.or(user_class),
+                user_type: user_type.or(user_class).unwrap_or_default(),
                 root_path,
                 columns,
                 tilecount,

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -32,7 +32,7 @@ pub struct WangSet {
     /// The name of the Wang set.
     pub name: String,
     /// The custom type of the Wang set, arbitrarily set by the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
     /// Type of Wang set.
     pub wang_set_type: WangSetType,
     /// The tile ID of the tile representing this Wang set.
@@ -91,7 +91,7 @@ impl WangSet {
 
         Ok(WangSet {
             name,
-            user_type,
+            user_type: user_type.unwrap_or_default(),
             wang_set_type,
             tile,
             wang_colors,

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -12,7 +12,7 @@ pub struct WangColor {
     /// The name of this color.
     pub name: String,
     /// The custom type of this color, arbitrarily set by the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
     #[allow(missing_docs)]
     pub color: Color,
     /// The tile ID of the tile representing this color.
@@ -53,7 +53,7 @@ impl WangColor {
 
         Ok(WangColor {
             name,
-            user_type,
+            user_type: user_type.unwrap_or_default(),
             color,
             tile,
             probability,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -820,11 +820,8 @@ fn test_reading_wang_sets() {
     );
     assert_eq!(tileset.wang_sets.len(), 3);
     let wangset_1 = tileset.wang_sets.get(0).unwrap();
-    assert_eq!(wangset_1.user_type.as_deref(), Some("VoidSet"));
-    assert_eq!(
-        wangset_1.wang_colors[0].user_type.as_deref(),
-        Some("VoidColor")
-    );
+    assert_eq!(wangset_1.user_type, "VoidSet");
+    assert_eq!(wangset_1.wang_colors[0].user_type, "VoidColor");
     let wangset_2 = tileset.wang_sets.get(1).unwrap();
     let tile_10 = wangset_2.wang_tiles.get(&10).unwrap();
     assert_eq!(tile_10.wang_id, WangId([2u8, 2, 0, 2, 0, 2, 2, 2]));


### PR DESCRIPTION
Changes the `user_type` fields on `Map`, `Tileset`, `LayerData`, `TileData`, `WangSet` and `WangColor` from `Option<String>` to `String`, which is empty when the `class` attribute is not set.

Previously the crate was inconsistent: `ObjectData` used a plain `String` while the other six sites used `Option<String>`. The plain string matches Tiled itself, which stores the class as a plain `QString` (empty when unset) on the common `Object` base class, and doesn't distinguish an absent `class` attribute from an empty one.