### PR TITLE
Deprecate the values of ObjectShape::Point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Option<String>` to `String`, which is empty when the `class` attribute is not set. This
   matches `ObjectData` as well as Tiled itself.
 
+### Deprecated
+- The values of `ObjectShape::Point`, since they merely duplicate the object's `x` and `y`
+  members. Match the variant with `ObjectShape::Point(..)` to avoid the deprecation
+  warnings. (#329)
+
 ## [0.15.1]
 ### Changed
 - The GGEZ example now handles tile rotation and mirroring. (#328)

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -295,7 +295,7 @@ impl MapHandler {
                 )?;
                 canvas.draw(&shape, draw_param);
             }
-            tiled::ObjectShape::Point(_, _) | tiled::ObjectShape::Text { .. } => {
+            tiled::ObjectShape::Point(..) | tiled::ObjectShape::Text { .. } => {
                 // Left as an exercise for the reader
             }
         }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -136,7 +136,15 @@ pub enum ObjectShape {
     Polygon {
         points: Vec<(f32, f32)>,
     },
-    Point(f32, f32),
+    /// A point marker.
+    ///
+    /// The values are deprecated, since they merely duplicate the object's `x` and `y` members
+    /// and will be removed in a future version. Match this variant with
+    /// `ObjectShape::Point(..)` to avoid the deprecation warnings.
+    Point(
+        #[deprecated = "use the object's `x` member instead"] f32,
+        #[deprecated = "use the object's `y` member instead"] f32,
+    ),
     Text {
         font_family: String,
         pixel_size: usize,
@@ -331,7 +339,10 @@ impl ObjectData {
                 Ok(())
             },
             "point" => |elem: crate::util::XmlElement<'_, R>| {
-                shape = Some(ObjectShape::Point(x, y));
+                #[allow(deprecated)]
+                {
+                    shape = Some(ObjectShape::Point(x, y));
+                }
                 parse_tag!(elem, {});
                 Ok(())
             },
@@ -353,7 +364,8 @@ impl ObjectData {
                     ObjectShape::Rect { .. } => ObjectShape::Rect { width, height },
                     ObjectShape::Ellipse { .. } => ObjectShape::Ellipse { width, height },
                     ObjectShape::Capsule { .. } => ObjectShape::Capsule { width, height },
-                    ObjectShape::Point(_, _) => ObjectShape::Point(x, y),
+                    #[allow(deprecated)]
+                    ObjectShape::Point(..) => ObjectShape::Point(x, y),
                     ObjectShape::Text {
                         font_family,
                         pixel_size,


### PR DESCRIPTION
The values of `ObjectShape::Point(f32, f32)` merely duplicate the object's own `x` and `y` members, and the TMX `<point>` element has no attributes of its own, so they were inconsistent with the other shape variants (see #329).

Rust supports `#[deprecated]` on individual tuple-variant fields, which gives exactly the behavior we want here:

- Binding or constructing the values warns, pointing at the object's `x`/`y` members instead.
- Merely handling the variant with `ObjectShape::Point(..)` stays warning-free, so consumers who don't rely on the redundant values are unaffected.

The variant doc explains the migration, and the values can then be dropped entirely in the release after 0.16.

Closes #329