### PR TITLE
Raise edition to 2024 and fix clippy lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `user_type` fields on `Map`, `Tileset`, `LayerData` and `TileData` changed from
   `Option<String>` to `String`, which is empty when the `class` attribute is not set. This
   matches `ObjectData` as well as Tiled itself.
+- Raised the Rust edition to 2024, which implies a minimum supported Rust version of
+  1.85. (#332)
 
 ### Deprecated
 - The values of `ObjectShape::Point`, since they merely duplicate the object's `x` and `y`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/mapeditor/rs-tiled"
 readme = "README.md"
 license = "MIT"
 authors = ["Matthew Hall <matthew@quickbeam.me.uk>"]
-edition = "2018"
+edition = "2024"
 include = ["src/**/*.rs", "README.md", "LICENSE", "CHANGELOG.md"]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ tiled = { version = ".....", features = ["wasm"] }
 ```
 
 - Second, since you cannot use the filesystem as normally on the web, you cannot use `FilesystemResourceReader`. As such,
-you'll need to implement your own `ResourceReader`. This is a pretty simple task, as you just need to return anything
-that is `Read`able when given a path, e.g.:
+  you'll need to implement your own `ResourceReader`. This is a pretty simple task, as you just need to return anything
+  that is `Read`able when given a path, e.g.:
 ```rust,ignore
 use std::io::Cursor;
 

--- a/examples/ggez/main.rs
+++ b/examples/ggez/main.rs
@@ -7,10 +7,11 @@ mod map;
 mod res_reader;
 
 use ggez::{
+    Context, GameResult,
     event::{self, MouseButton},
     graphics::{self, DrawParam},
     mint::Point2,
-    Context, GameResult, *,
+    *,
 };
 use map::MapHandler;
 use res_reader::GgezResourceReader;

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, f32::consts::FRAC_PI_2};
 
 use ggez::{
-    graphics::{self, Canvas, DrawParam, InstanceArray},
     Context, GameResult,
+    graphics::{self, Canvas, DrawParam, InstanceArray},
 };
 use tiled::TileLayer;
 

--- a/examples/sfml/tilesheet.rs
+++ b/examples/sfml/tilesheet.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use sfml::{
-    graphics::{FloatRect, Texture},
     SfBox,
+    graphics::{FloatRect, Texture},
 };
 use tiled::Tileset;
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::Result,
-    util::{get_attrs, parse_tag, XmlElement},
+    util::{XmlElement, get_attrs, parse_tag},
 };
 
 /// A structure describing a [frame] of a [TMX tile animation].

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,27 +154,34 @@ impl fmt::Display for Error {
                 )
             }
             Error::InvalidTileFound => write!(fmt, "Invalid tile found in map being parsed"),
-            Error::InvalidEncodingFormat { encoding: None, compression: None } =>
-                write!(
-                    fmt,
-                    "Deprecated combination of encoding and compression"
-                ),
-            Error::InvalidEncodingFormat { encoding, compression } =>
-                write!(
-                    fmt,
-                    "Unknown encoding or compression format or invalid combination of both (for tile layers): {} encoding with {} compression",
-                    encoding.as_deref().unwrap_or("no"),
-                    compression.as_deref().unwrap_or("no")
-                ),
-            Error::InvalidPropertyValue{description} =>
-                write!(fmt, "Invalid property value: {}", description),
-            Error::UnknownPropertyType { type_name } =>
-                write!(fmt, "Unknown property value type '{}'", type_name),
-            Error::TemplateHasNoObject => write!(fmt, "A template was found with no object element"),
-            Error::InvalidWangIdEncoding{read_string} =>
-                write!(fmt, "\"{}\" is not a valid WangId format", read_string),
-            Error::InvalidObjectData{description} =>
-                write!(fmt, "Invalid object data: {}", description),
+            Error::InvalidEncodingFormat {
+                encoding: None,
+                compression: None,
+            } => write!(fmt, "Deprecated combination of encoding and compression"),
+            Error::InvalidEncodingFormat {
+                encoding,
+                compression,
+            } => write!(
+                fmt,
+                "Unknown encoding or compression format or invalid combination of both (for tile layers): {} encoding with {} compression",
+                encoding.as_deref().unwrap_or("no"),
+                compression.as_deref().unwrap_or("no")
+            ),
+            Error::InvalidPropertyValue { description } => {
+                write!(fmt, "Invalid property value: {}", description)
+            }
+            Error::UnknownPropertyType { type_name } => {
+                write!(fmt, "Unknown property value type '{}'", type_name)
+            }
+            Error::TemplateHasNoObject => {
+                write!(fmt, "A template was found with no object element")
+            }
+            Error::InvalidWangIdEncoding { read_string } => {
+                write!(fmt, "\"{}\" is not a valid WangId format", read_string)
+            }
+            Error::InvalidObjectData { description } => {
+                write!(fmt, "Invalid object data: {}", description)
+            }
             Error::InvalidTileset(e) => write!(fmt, "{}", e),
         }
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::{
     error::Result,
     properties::Color,
-    util::{get_attrs, parse_tag, XmlElement},
+    util::{XmlElement, get_attrs, parse_tag},
 };
 
 /// A reference to an image stored somewhere within the filesystem.

--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::{
+    Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
     error::Result,
     layers::{LayerData, LayerTag},
-    properties::{parse_properties, Properties},
+    properties::{Properties, parse_properties},
     util::*,
-    Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
 };
 
 /// The raw data of a [`GroupLayer`]. Does not include a reference to its parent [`Map`](crate::Map).
@@ -121,7 +121,7 @@ impl<'map> GroupLayer<'map> {
     /// dbg!(nested_layers);
     /// # }
     /// ```
-    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'map>> + 'map {
+    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'map>> + 'map + use<'map> {
         let map: &'map crate::Map = self.map;
         self.data
             .layers

--- a/src/layers/image.rs
+++ b/src/layers/image.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, path::Path};
 
 use crate::{
-    parse_properties,
+    Error, Image, Properties, Result, parse_properties,
     util::{get_attrs, map_wrapper, parse_tag},
-    Error, Image, Properties, Result,
 };
 
 /// The raw data of an [`ImageLayer`]. Does not include a reference to its parent [`Map`](crate::Map).

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, sync::Arc};
 
 use crate::{
-    error::Result, properties::Properties, util::*, Color, Map, MapTilesetGid, ResourceCache,
-    ResourceReader, Tileset,
+    Color, Map, MapTilesetGid, ResourceCache, ResourceReader, Tileset, error::Result,
+    properties::Properties, util::*,
 };
 
 mod image;
@@ -69,6 +69,7 @@ impl LayerData {
         self.id
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new<R: std::io::BufRead>(
         elem: crate::util::XmlElement<'_, R>,
         tag: LayerTag,

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -1,10 +1,9 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::{
-    parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag},
     Color, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader, Result,
-    Tileset,
+    Tileset, parse_properties,
+    util::{get_attrs, map_wrapper, parse_tag},
 };
 
 /// The order in which the objects of an object layer are drawn.
@@ -157,7 +156,7 @@ impl<'map> ObjectLayer<'map> {
     /// # }
     /// ```
     #[inline]
-    pub fn objects(&self) -> impl ExactSizeIterator<Item = Object<'map>> + 'map {
+    pub fn objects(&self) -> impl ExactSizeIterator<Item = Object<'map>> + 'map + use<'map> {
         let map: &'map crate::Map = self.map;
         self.data
             .objects

--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -1,6 +1,6 @@
 use crate::{
-    util::{get_attrs, map_wrapper},
     LayerTile, LayerTileData, MapTilesetGid, Result,
+    util::{get_attrs, map_wrapper},
 };
 
 use super::util::parse_data_line;

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    util::{floor_div, get_attrs, map_wrapper, parse_tag},
     Error, LayerTile, LayerTileData, MapTilesetGid, Result,
+    util::{floor_div, get_attrs, map_wrapper, parse_tag},
 };
 
 use super::util::parse_data_line;
@@ -263,7 +263,9 @@ impl<'map> InfiniteTileLayer<'map> {
     /// # }
     /// ```
     #[inline]
-    pub fn chunks(&self) -> impl ExactSizeIterator<Item = ((i32, i32), Chunk<'map>)> + 'map {
+    pub fn chunks(
+        &self,
+    ) -> impl ExactSizeIterator<Item = ((i32, i32), Chunk<'map>)> + 'map + use<'map> {
         let map: &'map crate::Map = self.map;
         self.data
             .chunks

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    parse_properties,
+    Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset, parse_properties,
     util::{get_attrs, map_wrapper, parse_tag},
-    Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset,
 };
 
 mod finite;

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, io::Read};
 use base64::Engine;
 
 use crate::{
-    util::read_text_or_cdata, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result,
+    CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result, util::read_text_or_cdata,
 };
 
 pub(crate) fn parse_data_line<R: std::io::BufRead>(
@@ -63,7 +63,7 @@ fn decode_csv(text: &str, tilesets: &[MapTilesetGid]) -> Result<Vec<Option<Layer
             Err(e) => {
                 return Err(Error::CsvDecodingError(
                     CsvDecodingError::TileDataParseError(e),
-                ))
+                ));
             }
         }
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -9,12 +9,12 @@ use std::{
 };
 
 use crate::{
+    EmbeddedParseResultType, Layer, ResourceCache, ResourceReader,
     error::Result,
     layers::{LayerData, LayerTag},
-    properties::{parse_properties, Color, Properties},
+    properties::{Color, Properties, parse_properties},
     tileset::Tileset,
     util::{get_attrs, parse_tag},
-    EmbeddedParseResultType, Layer, ResourceCache, ResourceReader,
 };
 
 pub(crate) struct MapTilesetGid {
@@ -171,12 +171,12 @@ impl Map {
     /// # }
     /// ```
     #[inline]
-    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer> {
+    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'_>> {
         self.layers.iter().map(move |layer| Layer::new(self, layer))
     }
 
     /// Returns the top-level layer that has the specified index, if it exists.
-    pub fn get_layer(&self, index: usize) -> Option<Layer> {
+    pub fn get_layer(&self, index: usize) -> Option<Layer<'_>> {
         self.layers.get(index).map(|data| Layer::new(self, data))
     }
 }
@@ -261,7 +261,7 @@ impl Map {
                         tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset});
                     }
                     EmbeddedParseResultType::Embedded { tileset } => {
-                        tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset: Arc::new(tileset)});
+                        tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset: Arc::new(*tileset)});
                     },
                 };
                 Ok(())

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::{
+    Color, Gid, MapTilesetGid, ResourceCache, ResourceReader, Tile, TileId, Tileset,
     error::{Error, Result},
-    properties::{parse_properties, Properties},
+    properties::{Properties, parse_properties},
     template::Template,
     util::{get_attrs, map_wrapper, parse_tag, read_text_or_cdata},
-    Color, Gid, MapTilesetGid, ResourceCache, ResourceReader, Tile, TileId, Tileset,
 };
 
 /// The location of the tileset this tile is in
@@ -383,16 +383,16 @@ impl ObjectData {
                         height: _,
                     } => ObjectShape::Text {
                         font_family: font_family.clone(),
-                        pixel_size: pixel_size.clone(),
-                        wrap: wrap.clone(),
-                        color: color.clone(),
-                        bold: bold.clone(),
-                        italic: italic.clone(),
-                        underline: underline.clone(),
-                        strikeout: strikeout.clone(),
-                        kerning: kerning.clone(),
-                        halign: halign.clone(),
-                        valign: valign.clone(),
+                        pixel_size: *pixel_size,
+                        wrap: *wrap,
+                        color: *color,
+                        bold: *bold,
+                        italic: *italic,
+                        underline: *underline,
+                        strikeout: *strikeout,
+                        kerning: *kerning,
+                        halign: *halign,
+                        valign: *valign,
                         text: text.clone(),
                         width,
                         height,
@@ -527,7 +527,7 @@ impl ObjectData {
         let italic = italic == Some(1);
         let underline = underline == Some(1);
         let strikeout = strikeout == Some(1);
-        let kerning = kerning.map_or(true, |k| k == 1);
+        let kerning = kerning.is_none_or(|k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
         let contents = read_text_or_cdata(elem, |text| Ok(text.to_string()))?;

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use quick_xml::Reader;
 
-use crate::{util::parse_root_element, Error, Map, ResourceCache, ResourceReader, Result};
+use crate::{Error, Map, ResourceCache, ResourceReader, Result, util::parse_root_element};
 
 pub fn parse_map(
     path: &Path,

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use quick_xml::Reader;
 
-use crate::{util::parse_root_element, Error, ResourceCache, ResourceReader, Result, Tileset};
+use crate::{Error, ResourceCache, ResourceReader, Result, Tileset, util::parse_root_element};
 
 pub fn parse_tileset(
     path: &Path,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -48,6 +48,12 @@ impl FilesystemResourceReader {
     }
 }
 
+impl Default for FilesystemResourceReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ResourceReader for FilesystemResourceReader {
     type Resource = BufReader<File>;
     type Error = std::io::Error;

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use quick_xml::Reader;
 
 use crate::{
-    util::{parse_root_element, parse_tag, XmlElement},
     EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache, ResourceReader,
     Result, Tileset,
+    util::{XmlElement, parse_root_element, parse_tag},
 };
 
 /// A template, consisting of an object and a tileset
@@ -72,7 +72,7 @@ impl Template {
                         });
                     }
                     EmbeddedParseResultType::Embedded { tileset: embedded_tileset } => {
-                        tileset = Some(Arc::new(embedded_tileset));
+                        tileset = Some(Arc::new(*embedded_tileset));
                     },
                 };
                 tileset_gid.push(MapTilesetGid {

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashMap, path::Path};
 
 use crate::{
-    animation::{parse_animation, Frame},
+    ResourceCache, ResourceReader, Result, Tileset,
+    animation::{Frame, parse_animation},
     image::Image,
     layers::ObjectLayerData,
-    properties::{parse_properties, Properties},
+    properties::{Properties, parse_properties},
     util::{get_attrs, parse_tag},
-    ResourceCache, ResourceReader, Result, Tileset,
 };
 
 /// A tile ID, local to a tileset.

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -5,11 +5,11 @@ use std::str::FromStr;
 
 use crate::error::{Error, Result};
 use crate::image::Image;
-use crate::properties::{parse_properties, Properties};
+use crate::properties::{Properties, parse_properties};
 use crate::tile::TileData;
 use crate::{
-    util::{get_attrs, parse_tag},
     Gid, InvalidTilesetError, ResourceCache, ResourceReader, Tile, TileId,
+    util::{get_attrs, parse_tag},
 };
 
 mod wangset;
@@ -281,7 +281,7 @@ impl fmt::Display for ObjectAlignment {
 
 pub(crate) enum EmbeddedParseResultType {
     ExternalReference { tileset_path: PathBuf },
-    Embedded { tileset: Tileset },
+    Embedded { tileset: Box<Tileset> },
 }
 
 pub(crate) struct EmbeddedParseResult {
@@ -309,13 +309,13 @@ struct TilesetProperties {
 impl Tileset {
     /// Gets the tile with the specified ID from the tileset.
     #[inline]
-    pub fn get_tile(&self, id: TileId) -> Option<Tile> {
+    pub fn get_tile(&self, id: TileId) -> Option<Tile<'_>> {
         self.tiles.get(&id).map(|data| Tile::new(self, data))
     }
 
     /// Iterates through the tiles from this tileset.
     #[inline]
-    pub fn tiles(&self) -> impl ExactSizeIterator<Item = (TileId, Tile)> {
+    pub fn tiles(&self) -> impl ExactSizeIterator<Item = (TileId, Tile<'_>)> {
         self.tiles
             .iter()
             .map(move |(id, data)| (*id, Tile::new(self, data)))
@@ -394,7 +394,9 @@ impl Tileset {
         )
         .map(|tileset| EmbeddedParseResult {
             first_gid,
-            result_type: EmbeddedParseResultType::Embedded { tileset },
+            result_type: EmbeddedParseResultType::Embedded {
+                tileset: Box::new(tileset),
+            },
         })
     }
 

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -12,9 +12,8 @@ mod wang_tile;
 pub use wang_tile::*;
 
 /// Wang set's terrain brush connection type.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
 #[allow(missing_docs)]
-#[derive(Default)]
 pub enum WangSetType {
     Corner,
     Edge,

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    properties::{parse_properties, Properties},
-    util::{get_attrs, parse_tag},
     Result, TileId,
+    properties::{Properties, parse_properties},
+    util::{get_attrs, parse_tag},
 };
 
 mod wang_color;
@@ -14,16 +14,12 @@ pub use wang_tile::*;
 /// Wang set's terrain brush connection type.
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[allow(missing_docs)]
+#[derive(Default)]
 pub enum WangSetType {
     Corner,
     Edge,
+    #[default]
     Mixed,
-}
-
-impl Default for WangSetType {
-    fn default() -> Self {
-        WangSetType::Mixed
-    }
 }
 
 /// Raw data belonging to a WangSet.

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    properties::{parse_properties, Color, Properties},
-    util::{get_attrs, parse_tag},
     Result, TileId,
+    properties::{Color, Properties, parse_properties},
+    util::{get_attrs, parse_tag},
 };
 
 /// Stores the data of the Wang color.

--- a/src/tileset/wangset/wang_tile.rs
+++ b/src/tileset/wangset/wang_tile.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
 
 use crate::{
+    Result, TileId,
     error::Error,
     util::{get_attrs, parse_tag},
-    Result, TileId,
 };
 
 /// The Wang ID, stored as an array of 8 u8 values.

--- a/src/util.rs
+++ b/src/util.rs
@@ -300,7 +300,7 @@ pub fn floor_div(a: i32, b: i32) -> i32 {
 }
 use std::io::BufRead;
 
-use quick_xml::{events::BytesStart, events::Event, Reader};
+use quick_xml::{Reader, events::BytesStart, events::Event};
 
 use crate::{Error, Result};
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -46,10 +46,7 @@ impl World {
     /// Utility function to test a vec of filenames against all defined patterns.
     /// Returns a vec of results with the parsed [`WorldMap`]s if it matches the pattern.
     pub fn match_paths<P: AsRef<Path>>(&self, paths: &[P]) -> Vec<Result<WorldMap, Error>> {
-        paths
-            .into_iter()
-            .map(|path| self.match_path(path))
-            .collect()
+        paths.iter().map(|path| self.match_path(path)).collect()
     }
 }
 
@@ -112,7 +109,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 
@@ -121,7 +118,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 
@@ -130,7 +127,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 
@@ -170,7 +167,7 @@ pub(crate) fn parse_world(
     reader: &mut impl ResourceReader,
 ) -> Result<World, Error> {
     let mut path = reader
-        .read_from(&world_path)
+        .read_from(world_path)
         .map_err(|err| Error::ResourceLoadingError {
             path: world_path.to_owned(),
             err: Box::new(err),
@@ -183,8 +180,7 @@ pub(crate) fn parse_world(
             err: Box::new(err),
         })?;
 
-    let mut world: World =
-        serde_json::from_str(&world_string).map_err(|err| Error::JsonDecodingError(err))?;
+    let mut world: World = serde_json::from_str(&world_string).map_err(Error::JsonDecodingError)?;
 
     world.source = world_path.to_owned();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -115,7 +115,7 @@ fn test_world_pattern() {
 
     let paths = vec!["bad_map.tmx", "OVERFLOW-x099-y099.tmx"];
 
-    let errors = vec![
+    let errors = [
         "No match found for path: 'bad_map.tmx'",
         "Range error: Capture x * multiplierX causes overflow",
     ];
@@ -123,7 +123,7 @@ fn test_world_pattern() {
     let matches = e.match_paths(&paths);
 
     for (index, result) in matches.iter().enumerate() {
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
         assert_eq!(result.as_ref().err().unwrap().to_string(), errors[index]);
     }
 }
@@ -298,7 +298,7 @@ fn test_tile_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) = r.tilesets()[0]
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) = r.tilesets()[0]
         .get_tile(1)
         .unwrap()
         .properties
@@ -316,7 +316,7 @@ fn test_layer_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) =
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) =
         r.get_layer(0).unwrap().properties.get("prop3")
     {
         v.clone()
@@ -334,7 +334,7 @@ fn test_object_group_property() {
     let group_layer = r.get_layer(1).unwrap();
     let group_layer = group_layer.as_group_layer().unwrap();
     let sub_layer = group_layer.get_layer(0).unwrap();
-    let prop_value: bool = if let Some(&PropertyValue::BoolValue(ref v)) =
+    let prop_value: bool = if let Some(PropertyValue::BoolValue(v)) =
         sub_layer.properties.get("an object group property")
     {
         *v
@@ -349,7 +349,7 @@ fn test_tileset_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) =
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) =
         r.tilesets()[0].properties.get("tileset property")
     {
         v.clone()
@@ -453,8 +453,8 @@ fn test_repeat() {
             3 => {
                 assert_eq!(layer.name, "ImageLayer");
                 let image_layer = layer.as_image_layer().unwrap();
-                assert_eq!(image_layer.repeat_x, true);
-                assert_eq!(image_layer.repeat_y, true);
+                assert!(image_layer.repeat_x);
+                assert!(image_layer.repeat_y);
             }
             _ => panic!("unexpected layer"),
         }
@@ -808,7 +808,7 @@ fn test_reading_wang_sets() {
         .unwrap();
 
     // We will pick some random data from the wangsets for tessting
-    let tileset = map.tilesets().get(0).unwrap();
+    let tileset = map.tilesets().first().unwrap();
     assert_eq!(
         tileset.transformations,
         tiled::Transformations {
@@ -819,7 +819,7 @@ fn test_reading_wang_sets() {
         }
     );
     assert_eq!(tileset.wang_sets.len(), 3);
-    let wangset_1 = tileset.wang_sets.get(0).unwrap();
+    let wangset_1 = tileset.wang_sets.first().unwrap();
     assert_eq!(wangset_1.user_type, "VoidSet");
     assert_eq!(wangset_1.wang_colors[0].user_type, "VoidColor");
     let wangset_2 = tileset.wang_sets.get(1).unwrap();
@@ -857,7 +857,7 @@ fn test_text_object() {
         } => {
             assert_eq!(font_family.as_str(), "sans-serif");
             assert_eq!(*pixel_size, 16);
-            assert_eq!(*wrap, false);
+            assert!(!(*wrap));
             assert_eq!(
                 *color,
                 Color {
@@ -867,11 +867,11 @@ fn test_text_object() {
                     alpha: 100
                 }
             );
-            assert_eq!(*bold, true);
-            assert_eq!(*italic, true);
-            assert_eq!(*underline, true);
-            assert_eq!(*strikeout, true);
-            assert_eq!(*kerning, true);
+            assert!(*bold);
+            assert!(*italic);
+            assert!(*underline);
+            assert!(*strikeout);
+            assert!(*kerning);
             assert_eq!(*halign, HorizontalAlignment::Center);
             assert_eq!(*valign, VerticalAlignment::Bottom);
             assert_eq!(text.as_str(), "Test");


### PR DESCRIPTION
Supersedes #332, which had become unmergeable (based on the pre-quick-xml codebase, with no maintainer push access to the fork).

- `edition = "2024"`, migrated stepwise with `cargo fix --edition`. The substantive changes were precise-capture bounds (`+ use<'map>`) on the two RPIT methods that return borrowing iterators, preserving their exact 2021 capture semantics. The `expr_2021` macro fragment specifiers the migration inserted were simplified back to `expr`, since the 2024 meaning (accepting `const`/`_` expressions) is harmless for our macros.
- All clippy lints fixed; `cargo clippy --all-targets` is now warning-free. Notables: `EmbeddedParseResultType::Embedded` now boxes its `Tileset` (large-variant lint, internal type only), `FilesystemResourceReader` gained a `Default` impl, and the README's doc-list indentation was corrected. The internal `LayerData::new` keeps its 8 arguments with an explicit allow.
- Part of the diff is rustfmt's style edition 2024 reformatting, which follows the edition.
- **MSRV**: the 2024 edition implies rustc 1.85, and `cargo +1.85 check --all-targets` passes with a fresh dependency resolution, so no separate `rust-version` declaration is needed; the edition states the floor exactly.

The MSRV/edition bump lands in 0.16 alongside the other breaking changes, and is noted in the changelog.