### PR TITLE
Merge next to current for the switch to a single-branch workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ current, next ]
+    branches: [ main ]
   pull_request:
-    branches: [ current, next ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added the `Oblique` variant to the `Orientation` enum, which is a breaking
+  change for code that matches on it exhaustively.
+- Added `Map` `skew_x` and `skew_y` fields parsed from TMX `skewx`/`skewy`.
+
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.
+- The `user_type` fields on `Map`, `Tileset`, `LayerData` and `TileData` changed from
+  `Option<String>` to `String`, which is empty when the `class` attribute is not set. This
+  matches `ObjectData` as well as Tiled itself.
 
 ## [0.15.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `user_type` fields on `Map`, `Tileset`, `LayerData` and `TileData` changed from
   `Option<String>` to `String`, which is empty when the `class` attribute is not set. This
   matches `ObjectData` as well as Tiled itself.
+- Raised the Rust edition to 2024, which implies a minimum supported Rust version of
+  1.85. (#332)
 
 ### Deprecated
 - The values of `ObjectShape::Point`, since they merely duplicate the object's `x` and `y`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Option<String>` to `String`, which is empty when the `class` attribute is not set. This
   matches `ObjectData` as well as Tiled itself.
 
+### Deprecated
+- The values of `ObjectShape::Point`, since they merely duplicate the object's `x` and `y`
+  members. Match the variant with `ObjectShape::Point(..)` to avoid the deprecation
+  warnings. (#329)
+
 ## [0.15.1]
 ### Changed
 - The GGEZ example now handles tile rotation and mirroring. (#328)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Switched from `xml-rs` to `quick-xml` to speed up XML parsing.
+
 ## [0.15.0]
 ### Added
 - New `ImageLayer` `repeat_x`/`y` fields are now parsed from map image layers. (#324)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   change for code that matches on it exhaustively.
 - Added `Map` `skew_x` and `skew_y` fields parsed from TMX `skewx`/`skewy`.
 - Added support for list properties via `PropertyValue::ListValue`. (#338, #340, #341)
+- Added `Tileset` `tile_render_size`, `fill_mode` and `object_alignment` fields parsed from
+  the TMX `tilerendersize`, `fillmode` and `objectalignment` attributes.
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `Oblique` variant to the `Orientation` enum, which is a breaking
   change for code that matches on it exhaustively.
 - Added `Map` `skew_x` and `skew_y` fields parsed from TMX `skewx`/`skewy`.
+- Added support for list properties via `PropertyValue::ListValue`. (#338, #340, #341)
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code that matches on it exhaustively.
 - Added `LayerData` `blend_mode` field parsed from the TMX `mode` attribute.
 - Added `ObjectData` `opacity` field parsed from the TMX `opacity` attribute.
+- Added `Map` `render_order`, `parallax_origin_x` and `parallax_origin_y` fields parsed from
+  the TMX `renderorder`, `parallaxoriginx` and `parallaxoriginy` attributes.
+- Added `ObjectLayerData` `draw_order` field parsed from the TMX `draworder` attribute.
+- Added `Tileset` `transformations` field parsed from the TMX `transformations` element.
+- Added `WangSet` and `WangColor` `user_type` fields parsed from the TMX `class` attribute.
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for list properties via `PropertyValue::ListValue`. (#338, #340, #341)
 - Added `Tileset` `tile_render_size`, `fill_mode` and `object_alignment` fields parsed from
   the TMX `tilerendersize`, `fillmode` and `objectalignment` attributes.
+- Added the `Capsule` variant to the `ObjectShape` enum, which is a breaking change for
+  code that matches on it exhaustively.
+- Added `LayerData` `blend_mode` field parsed from the TMX `mode` attribute.
+- Added `ObjectData` `opacity` field parsed from the TMX `opacity` attribute.
 
 ### Changed
 - Switched from `xml-rs` to `quick-xml` to speed up XML parsing.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 * Thorbjørn Lindeijer
 * Alejandro Perea
 * David Mahany
+* Andrew Minnich

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/mapeditor/rs-tiled"
 readme = "README.md"
 license = "MIT"
 authors = ["Matthew Hall <matthew@quickbeam.me.uk>"]
-edition = "2018"
+edition = "2024"
 include = ["src/**/*.rs", "README.md", "LICENSE", "CHANGELOG.md"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/ggez/main.rs"
 
 [dependencies]
 base64 = "0.22.1"
-xml-rs = "0.8.4"
+quick-xml = "0.31.0"
 zstd = { version = "0.13.1", optional = true, default-features = false }
 flate2 = "1.0.28"
 serde = { version = "1.0.216", optional = true }

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ tiled = { version = ".....", features = ["wasm"] }
 ```
 
 - Second, since you cannot use the filesystem as normally on the web, you cannot use `FilesystemResourceReader`. As such,
-you'll need to implement your own `ResourceReader`. This is a pretty simple task, as you just need to return anything
-that is `Read`able when given a path, e.g.:
+  you'll need to implement your own `ResourceReader`. This is a pretty simple task, as you just need to return anything
+  that is `Read`able when given a path, e.g.:
 ```rust,ignore
 use std::io::Cursor;
 

--- a/assets/tiled_object_capsule.tmx
+++ b/assets/tiled_object_capsule.tmx
@@ -6,7 +6,7 @@
 0,0
 </data>
  </layer>
- <objectgroup id="2" name="Object Layer 1" mode="add">
+ <objectgroup id="2" name="Object Layer 1" mode="add" draworder="index">
   <object id="1" x="8" y="8" width="16" height="48" opacity="0.5">
    <capsule/>
   </object>

--- a/assets/tiled_object_capsule.tmx
+++ b/assets/tiled_object_capsule.tmx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.12.0" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="3">
+ <layer id="1" name="Tile Layer 1" width="2" height="2" mode="multiply">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1" mode="add">
+  <object id="1" x="8" y="8" width="16" height="48" opacity="0.5">
+   <capsule/>
+  </object>
+  <object id="2" x="32" y="0" width="32" height="32"/>
+ </objectgroup>
+</map>

--- a/assets/tiled_object_list_property.tmx
+++ b/assets/tiled_object_list_property.tmx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.12.1" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="5">
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="2" x="0" y="0" width="32" height="32">
+   <properties>
+    <property name="list property" type="list">
+     <item type="object" value="4"/>
+     <item type="object" value="3"/>
+     <item type="bool" value="true"/>
+    </property>
+   </properties>
+  </object>
+  <object id="3" x="32" y="32" width="32" height="32">
+   <properties>
+    <property name="object property" type="object" value="0"/>
+   </properties>
+  </object>
+  <object id="4" x="32" y="0" width="32" height="32">
+   <properties>
+    <property name="object property" type="object" value="0"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/assets/tiled_object_nested_list_property.tmx
+++ b/assets/tiled_object_nested_list_property.tmx
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.12.1" orientation="orthogonal" renderorder="right-down" width="2" height="2" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="5">
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="2" x="0" y="0" width="32" height="32">
+   <properties>
+    <property name="list property" type="list">
+     <item type="object" value="4"/>
+     <item type="object" value="3"/>
+     <item type="bool" value="true"/>
+     <item type="list">
+      <item type="bool" value="false"/>
+      <item type="bool" value="true"/>
+      <item type="list">
+       <item type="bool" value="false"/>
+       <item type="bool" value="true"/>
+      </item>
+     </item>
+     <item type="list">
+      <item type="class" propertytype="ListClass">
+       <properties>
+        <property name="list" type="list">
+         <item type="class" propertytype="Class">
+          <properties>
+           <property name="member_1" value="test"/>
+           <property name="member_2" type="int" value="10"/>
+          </properties>
+         </item>
+        </property>
+       </properties>
+      </item>
+     </item>
+     <item type="int" value="7"/>
+    </property>
+   </properties>
+  </object>
+  <object id="3" x="32" y="32" width="32" height="32">
+   <properties>
+    <property name="object property" type="object" value="0"/>
+   </properties>
+  </object>
+  <object id="4" x="32" y="0" width="32" height="32">
+   <properties>
+    <property name="object property" type="object" value="0"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/assets/tiled_oblique.tmx
+++ b/assets/tiled_oblique.tmx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.12.0" orientation="oblique" renderorder="right-down" width="4" height="4" tilewidth="32" tileheight="32" infinite="0" skewx="16" skewy="8" nextlayerid="2" nextobjectid="1">
+ <tileset firstgid="1" source="tilesheet.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="4" height="4">
+  <data encoding="csv">
+1,2,3,4,
+5,6,7,8,
+9,10,11,12,
+13,14,15,16
+</data>
+ </layer>
+</map>

--- a/assets/tiled_parallax.tmx
+++ b/assets/tiled_parallax.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.7.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="4" nextobjectid="1">
+<map version="1.5" tiledversion="1.7.1" orientation="orthogonal" renderorder="right-up" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" parallaxoriginx="120" parallaxoriginy="-40.5" nextlayerid="4" nextobjectid="1">
  <tileset firstgid="1" source="tilesheet.tsx"/>
  <layer id="3" name="Background" width="10" height="10" parallaxx="0.5" parallaxy="0.75">
   <data encoding="csv">

--- a/assets/tilesheet_render_options.tsx
+++ b/assets/tilesheet_render_options.tsx
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.10" tiledversion="1.12.0" name="tilesheet_render_options" tilewidth="32" tileheight="32" tilecount="84" columns="14" objectalignment="topleft" tilerendersize="grid" fillmode="preserve-aspect-fit">
+ <image source="tilesheet.png" width="448" height="192"/>
+</tileset>

--- a/assets/tilesheet_wangsets.tsx
+++ b/assets/tilesheet_wangsets.tsx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tileset version="1.8" tiledversion="1.8.5" name="tilesheet_wangsets" tilewidth="32" tileheight="32" tilecount="84" columns="14">
  <image source="tilesheet.png" width="448" height="192"/>
+ <transformations hflip="1" vflip="1" rotate="0" preferuntransformed="1"/>
  <wangsets>
-  <wangset name="Void" type="mixed" tile="-1">
-   <wangcolor name="" color="#ff0000" tile="-1" probability="1"/>
+  <wangset name="Void" type="mixed" tile="-1" class="VoidSet">
+   <wangcolor name="" color="#ff0000" tile="-1" probability="1" class="VoidColor"/>
    <wangtile tileid="0" wangid="1,1,0,0,0,0,0,1"/>
    <wangtile tileid="1" wangid="0,0,0,1,1,1,0,0"/>
    <wangtile tileid="14" wangid="0,0,0,0,0,1,1,1"/>

--- a/examples/ggez/main.rs
+++ b/examples/ggez/main.rs
@@ -7,10 +7,11 @@ mod map;
 mod res_reader;
 
 use ggez::{
+    Context, GameResult,
     event::{self, MouseButton},
     graphics::{self, DrawParam},
     mint::Point2,
-    Context, GameResult, *,
+    *,
 };
 use map::MapHandler;
 use res_reader::GgezResourceReader;

--- a/examples/ggez/main.rs
+++ b/examples/ggez/main.rs
@@ -44,9 +44,15 @@ struct Game {
 
 impl Game {
     fn new(ctx: &mut ggez::Context) -> GameResult<Self> {
+        // The map to load can be given as an argument, and is resolved relative to the
+        // repository's `/assets` directory
+        let map_path = std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| "/tiled_base64_external.tmx".to_string());
+
         // Load the map, using a loader with `GgezResourceReader` for reading from the ggez filesystem
         let mut loader = tiled::Loader::with_reader(GgezResourceReader(&mut ctx.fs));
-        let map = loader.load_tmx_map("/tiled_base64_external.tmx").unwrap();
+        let map = loader.load_tmx_map(map_path).unwrap();
 
         let map_handler = MapHandler::new(map, ctx).unwrap();
 

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, f32::consts::FRAC_PI_2};
 
 use ggez::{
-    graphics::{self, Canvas, DrawParam, InstanceArray},
     Context, GameResult,
+    graphics::{self, Canvas, DrawParam, InstanceArray},
 };
 use tiled::TileLayer;
 

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -258,6 +258,17 @@ impl MapHandler {
                 )?;
                 canvas.draw(&shape, draw_param);
             }
+            tiled::ObjectShape::Capsule { width, height } => {
+                let bounds = graphics::Rect::new(object.x, object.y, *width, *height);
+                let shape = graphics::Mesh::new_rounded_rectangle(
+                    ctx,
+                    graphics::DrawMode::stroke(2.0),
+                    bounds,
+                    width.min(*height) / 2.0,
+                    graphics::Color::CYAN,
+                )?;
+                canvas.draw(&shape, draw_param);
+            }
             tiled::ObjectShape::Polyline { points } => {
                 let points: Vec<_> = points
                     .iter()

--- a/examples/ggez/map.rs
+++ b/examples/ggez/map.rs
@@ -295,7 +295,7 @@ impl MapHandler {
                 )?;
                 canvas.draw(&shape, draw_param);
             }
-            tiled::ObjectShape::Point(_, _) | tiled::ObjectShape::Text { .. } => {
+            tiled::ObjectShape::Point(..) | tiled::ObjectShape::Text { .. } => {
                 // Left as an exercise for the reader
             }
         }

--- a/examples/sfml/tilesheet.rs
+++ b/examples/sfml/tilesheet.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use sfml::{
-    graphics::{FloatRect, Texture},
     SfBox,
+    graphics::{FloatRect, Texture},
 };
 use tiled::Tileset;
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -1,10 +1,8 @@
 //! Structures related to tile animations.
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::{Error, Result},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    error::Result,
+    util::{get_attrs, parse_tag, XmlElement},
 };
 
 /// A structure describing a [frame] of a [TMX tile animation].
@@ -20,25 +18,24 @@ pub struct Frame {
 }
 
 impl Frame {
-    pub(crate) fn new(attrs: Vec<OwnedAttribute>) -> Result<Frame> {
+    pub(crate) fn new<R: std::io::BufRead>(elem: XmlElement<'_, R>) -> Result<Frame> {
         let (tile_id, duration) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "tileid" => tile_id ?= v.parse::<u32>(),
                 "duration" => duration ?= v.parse::<u32>(),
             }
             (tile_id, duration)
         );
+        parse_tag!(elem, {});
         Ok(Frame { tile_id, duration })
     }
 }
 
-pub(crate) fn parse_animation(
-    parser: &mut impl Iterator<Item = XmlEventResult>,
-) -> Result<Vec<Frame>> {
+pub(crate) fn parse_animation<R: std::io::BufRead>(elem: XmlElement<'_, R>) -> Result<Vec<Frame>> {
     let mut animation = Vec::new();
-    parse_tag!(parser, "animation", {
-        "frame" => |attrs| {
-            animation.push(Frame::new(attrs)?);
+    parse_tag!(elem, {
+        "frame" => |elem| {
+            animation.push(Frame::new(elem)?);
             Ok(())
         },
     });

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::Result,
-    util::{get_attrs, parse_tag, XmlElement},
+    util::{XmlElement, get_attrs, parse_tag},
 };
 
 /// A structure describing a [frame] of a [TMX tile animation].

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,27 +154,34 @@ impl fmt::Display for Error {
                 )
             }
             Error::InvalidTileFound => write!(fmt, "Invalid tile found in map being parsed"),
-            Error::InvalidEncodingFormat { encoding: None, compression: None } =>
-                write!(
-                    fmt,
-                    "Deprecated combination of encoding and compression"
-                ),
-            Error::InvalidEncodingFormat { encoding, compression } =>
-                write!(
-                    fmt,
-                    "Unknown encoding or compression format or invalid combination of both (for tile layers): {} encoding with {} compression",
-                    encoding.as_deref().unwrap_or("no"),
-                    compression.as_deref().unwrap_or("no")
-                ),
-            Error::InvalidPropertyValue{description} =>
-                write!(fmt, "Invalid property value: {}", description),
-            Error::UnknownPropertyType { type_name } =>
-                write!(fmt, "Unknown property value type '{}'", type_name),
-            Error::TemplateHasNoObject => write!(fmt, "A template was found with no object element"),
-            Error::InvalidWangIdEncoding{read_string} =>
-                write!(fmt, "\"{}\" is not a valid WangId format", read_string),
-            Error::InvalidObjectData{description} =>
-                write!(fmt, "Invalid object data: {}", description),
+            Error::InvalidEncodingFormat {
+                encoding: None,
+                compression: None,
+            } => write!(fmt, "Deprecated combination of encoding and compression"),
+            Error::InvalidEncodingFormat {
+                encoding,
+                compression,
+            } => write!(
+                fmt,
+                "Unknown encoding or compression format or invalid combination of both (for tile layers): {} encoding with {} compression",
+                encoding.as_deref().unwrap_or("no"),
+                compression.as_deref().unwrap_or("no")
+            ),
+            Error::InvalidPropertyValue { description } => {
+                write!(fmt, "Invalid property value: {}", description)
+            }
+            Error::UnknownPropertyType { type_name } => {
+                write!(fmt, "Unknown property value type '{}'", type_name)
+            }
+            Error::TemplateHasNoObject => {
+                write!(fmt, "A template was found with no object element")
+            }
+            Error::InvalidWangIdEncoding { read_string } => {
+                write!(fmt, "\"{}\" is not a valid WangId format", read_string)
+            }
+            Error::InvalidObjectData { description } => {
+                write!(fmt, "Invalid object data: {}", description)
+            }
             Error::InvalidTileset(e) => write!(fmt, "{}", e),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,7 @@ pub enum Error {
     /// An error occurred when decoding a csv encoded dataset.
     CsvDecodingError(CsvDecodingError),
     /// An error occurred when parsing an XML file, such as a TMX or TSX file.
-    XmlDecodingError(xml::reader::Error),
+    XmlDecodingError(quick_xml::Error),
     #[cfg(feature = "world")]
     /// An error occurred when attempting to deserialize a JSON file.
     JsonDecodingError(serde_json::Error),

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,11 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::{Error, Result},
+    error::Result,
     properties::Color,
-    util::*,
+    util::{get_attrs, parse_tag, XmlElement},
 };
 
 /// A reference to an image stored somewhere within the filesystem.
@@ -68,22 +66,21 @@ pub struct Image {
 }
 
 impl Image {
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: XmlElement<'_, R>,
         path_relative_to: impl AsRef<Path>,
     ) -> Result<Image> {
         let (c, (s, w, h)) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("trans") => trans ?= v.parse(),
-                "source" => source = v,
+                "source" => source = v.to_string(),
                 "width" => width ?= v.parse::<i32>(),
                 "height" => height ?= v.parse::<i32>(),
             }
             (trans, (source, width, height))
         );
 
-        parse_tag!(parser, "image", {});
+        parse_tag!(elem, {});
         Ok(Image {
             source: path_relative_to.as_ref().join(s),
             width: w,

--- a/src/image.rs
+++ b/src/image.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::{
     error::Result,
     properties::Color,
-    util::{get_attrs, parse_tag, XmlElement},
+    util::{XmlElement, get_attrs, parse_tag},
 };
 
 /// A reference to an image stored somewhere within the filesystem.

--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::{
+    Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
     error::Result,
     layers::{LayerData, LayerTag},
-    properties::{parse_properties, Properties},
+    properties::{Properties, parse_properties},
     util::*,
-    Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
 };
 
 /// The raw data of a [`GroupLayer`]. Does not include a reference to its parent [`Map`](crate::Map).
@@ -121,7 +121,7 @@ impl<'map> GroupLayer<'map> {
     /// dbg!(nested_layers);
     /// # }
     /// ```
-    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'map>> + 'map {
+    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'map>> + 'map + use<'map> {
         let map: &'map crate::Map = self.map;
         self.data
             .layers

--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -5,7 +5,7 @@ use crate::{
     layers::{LayerData, LayerTag},
     properties::{parse_properties, Properties},
     util::*,
-    Error, Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
+    Layer, MapTilesetGid, ResourceCache, ResourceReader, Tileset,
 };
 
 /// The raw data of a [`GroupLayer`]. Does not include a reference to its parent [`Map`](crate::Map).
@@ -15,8 +15,8 @@ pub struct GroupLayerData {
 }
 
 impl GroupLayerData {
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         infinite: bool,
         map_path: &Path,
         tilesets: &[MapTilesetGid],
@@ -26,61 +26,61 @@ impl GroupLayerData {
     ) -> Result<(Self, Properties)> {
         let mut properties = HashMap::new();
         let mut layers = Vec::new();
-        parse_tag!(parser, "group", {
-            "layer" => |attrs| {
+        parse_tag!(elem, {
+            "layer" => |elem| {
                 layers.push(LayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     LayerTag::Tiles,
                     infinite,
                     map_path,
                     tilesets,
-                    for_tileset.as_ref().cloned(),reader,
+                    for_tileset.as_ref().cloned(),
+                    reader,
                     cache
                 )?);
                 Ok(())
             },
-            "imagelayer" => |attrs| {
+            "imagelayer" => |elem| {
                 layers.push(LayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     LayerTag::Image,
                     infinite,
                     map_path,
                     tilesets,
-                    for_tileset.as_ref().cloned(),reader,
+                    for_tileset.as_ref().cloned(),
+                    reader,
                     cache
                 )?);
                 Ok(())
             },
-            "objectgroup" => |attrs| {
+            "objectgroup" => |elem| {
                 layers.push(LayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     LayerTag::Objects,
                     infinite,
                     map_path,
                     tilesets,
-                    for_tileset.as_ref().cloned(),reader,
+                    for_tileset.as_ref().cloned(),
+                    reader,
                     cache
                 )?);
                 Ok(())
             },
-            "group" => |attrs| {
+            "group" => |elem| {
                 layers.push(LayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     LayerTag::Group,
                     infinite,
                     map_path,
                     tilesets,
-                    for_tileset.as_ref().cloned(),reader,
+                    for_tileset.as_ref().cloned(),
+                    reader,
                     cache
                 )?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/layers/image.rs
+++ b/src/layers/image.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, path::Path};
 
 use crate::{
-    parse_properties,
+    Error, Image, Properties, Result, parse_properties,
     util::{get_attrs, map_wrapper, parse_tag},
-    Error, Image, Properties, Result,
 };
 
 /// The raw data of an [`ImageLayer`]. Does not include a reference to its parent [`Map`](crate::Map).

--- a/src/layers/image.rs
+++ b/src/layers/image.rs
@@ -1,10 +1,8 @@
 use std::{collections::HashMap, path::Path};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
+    util::{get_attrs, map_wrapper, parse_tag},
     Error, Image, Properties, Result,
 };
 
@@ -20,9 +18,8 @@ pub struct ImageLayerData {
 }
 
 impl ImageLayerData {
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         map_path: &Path,
     ) -> Result<(Self, Properties)> {
         let mut image: Option<Image> = None;
@@ -32,20 +29,20 @@ impl ImageLayerData {
 
         // Parse repeat attributes from the imagelayer tag
         let (repeat_x, repeat_y) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("repeatx") => repeat_x ?= v.parse::<i32>().map(|val| val == 1),
                 Some("repeaty") => repeat_y ?= v.parse::<i32>().map(|val| val == 1),
             }
             (repeat_x, repeat_y)
         );
 
-        parse_tag!(parser, "imagelayer", {
-            "image" => |attrs| {
-                image = Some(Image::new(parser, attrs, path_relative_to)?);
+        parse_tag!(elem, {
+            "image" => |elem| {
+                image = Some(Image::new(elem, path_relative_to)?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -57,7 +57,7 @@ pub struct LayerData {
     /// The layer's custom properties, as arbitrarily set by the user.
     pub properties: Properties,
     /// The layer's type, which is arbitrarily setby the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
     layer_type: LayerDataType,
 }
 
@@ -155,7 +155,7 @@ impl LayerData {
             tint_color,
             name: name.unwrap_or_default(),
             id: id.unwrap_or(0),
-            user_type: user_type.or(user_class),
+            user_type: user_type.or(user_class).unwrap_or_default(),
             properties,
             layer_type: ty,
         })

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -48,6 +48,10 @@ pub struct LayerData {
     pub parallax_y: f32,
     /// The layer's opacity.
     pub opacity: f32,
+    /// The blend mode to use when rendering this layer, `normal` by default. Other values
+    /// written by Tiled are `add`, `multiply`, `screen`, `overlay`, `darken`, `lighten`,
+    /// `color-dodge`, `color-burn`, `hard-light`, `soft-light`, `difference` and `exclusion`.
+    pub blend_mode: String,
     /// The layer's tint color.
     pub tint_color: Option<Color>,
     /// The layer's custom properties, as arbitrarily set by the user.
@@ -77,6 +81,7 @@ impl LayerData {
     ) -> Result<Self> {
         let (
             opacity,
+            blend_mode,
             tint_color,
             visible,
             offset_x,
@@ -90,6 +95,7 @@ impl LayerData {
         ) = get_attrs!(
             for v in (elem.attrs) {
                 Some("opacity") => opacity ?= v.parse(),
+                Some("mode") => blend_mode = v.to_string(),
                 Some("tintcolor") => tint_color ?= v.parse(),
                 Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
                 Some("offsetx") => offset_x ?= v.parse(),
@@ -101,7 +107,7 @@ impl LayerData {
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
             }
-            (opacity, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type, user_class)
+            (opacity, blend_mode, tint_color, visible, offset_x, offset_y, parallax_x, parallax_y, name, id, user_type, user_class)
         );
 
         let (ty, properties) = match tag {
@@ -145,6 +151,7 @@ impl LayerData {
             parallax_x: parallax_x.unwrap_or(1.0),
             parallax_y: parallax_y.unwrap_or(1.0),
             opacity: opacity.unwrap_or(1.0),
+            blend_mode: blend_mode.unwrap_or_else(|| "normal".to_string()),
             tint_color,
             name: name.unwrap_or_default(),
             id: id.unwrap_or(0),

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -1,7 +1,5 @@
 use std::{path::Path, sync::Arc};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     error::Result, properties::Properties, util::*, Color, Map, MapTilesetGid, ResourceCache,
     ResourceReader, Tileset,
@@ -67,9 +65,8 @@ impl LayerData {
         self.id
     }
 
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         tag: LayerTag,
         infinite: bool,
         map_path: &Path,
@@ -91,7 +88,7 @@ impl LayerData {
             user_type,
             user_class,
         ) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("opacity") => opacity ?= v.parse(),
                 Some("tintcolor") => tint_color ?= v.parse(),
                 Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
@@ -99,7 +96,7 @@ impl LayerData {
                 Some("offsety") => offset_y ?= v.parse(),
                 Some("parallaxx") => parallax_x ?= v.parse(),
                 Some("parallaxy") => parallax_y ?= v.parse(),
-                Some("name") => name = v,
+                Some("name") => name = v.to_string(),
                 Some("id") => id ?= v.parse(),
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
@@ -109,13 +106,12 @@ impl LayerData {
 
         let (ty, properties) = match tag {
             LayerTag::Tiles => {
-                let (ty, properties) = TileLayerData::new(parser, attrs, infinite, tilesets)?;
+                let (ty, properties) = TileLayerData::new(elem, infinite, tilesets)?;
                 (LayerDataType::Tiles(ty), properties)
             }
             LayerTag::Objects => {
                 let (ty, properties) = ObjectLayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     Some(tilesets),
                     for_tileset,
                     map_path.parent().ok_or(crate::Error::PathIsNotFile)?,
@@ -125,12 +121,12 @@ impl LayerData {
                 (LayerDataType::Objects(ty), properties)
             }
             LayerTag::Image => {
-                let (ty, properties) = ImageLayerData::new(parser, attrs, map_path)?;
+                let (ty, properties) = ImageLayerData::new(elem, map_path)?;
                 (LayerDataType::Image(ty), properties)
             }
             LayerTag::Group => {
                 let (ty, properties) = GroupLayerData::new(
-                    parser,
+                    elem,
                     infinite,
                     map_path,
                     tilesets,

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, sync::Arc};
 
 use crate::{
-    error::Result, properties::Properties, util::*, Color, Map, MapTilesetGid, ResourceCache,
-    ResourceReader, Tileset,
+    Color, Map, MapTilesetGid, ResourceCache, ResourceReader, Tileset, error::Result,
+    properties::Properties, util::*,
 };
 
 mod image;
@@ -69,6 +69,7 @@ impl LayerData {
         self.id
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new<R: std::io::BufRead>(
         elem: crate::util::XmlElement<'_, R>,
         tag: LayerTag,

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -7,12 +7,64 @@ use crate::{
     Tileset,
 };
 
+/// The order in which the objects of an object layer are drawn.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub enum DrawOrder {
+    /// The objects are drawn sorted by their y-coordinate.
+    #[default]
+    TopDown,
+    /// The objects are drawn in the order of appearance in the map file, which can be manually
+    /// arranged in the editor.
+    Index,
+}
+
+#[derive(Debug)]
+/// An error arising from trying to parse a [`DrawOrder`] that is not valid.
+pub struct DrawOrderParseError {
+    /// The invalid string found.
+    pub str_found: String,
+}
+
+impl std::fmt::Display for DrawOrderParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "failed to parse draw order, valid options are `topdown` and `index` \
+        but got `{}` instead",
+            self.str_found
+        ))
+    }
+}
+
+impl std::str::FromStr for DrawOrder {
+    type Err = DrawOrderParseError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "topdown" => Ok(DrawOrder::TopDown),
+            "index" => Ok(DrawOrder::Index),
+            _ => Err(DrawOrderParseError {
+                str_found: s.to_owned(),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for DrawOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DrawOrder::TopDown => write!(f, "topdown"),
+            DrawOrder::Index => write!(f, "index"),
+        }
+    }
+}
+
 /// Raw data referring to a map object layer or tile collision data.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ObjectLayerData {
     objects: Vec<ObjectData>,
     /// The color used in the editor to display objects in this layer.
     pub colour: Option<Color>,
+    /// The order in which the objects in this layer are drawn.
+    pub draw_order: DrawOrder,
 }
 
 impl ObjectLayerData {
@@ -27,12 +79,14 @@ impl ObjectLayerData {
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<(ObjectLayerData, Properties)> {
-        let c = get_attrs!(
+        let (c, draw_order) = get_attrs!(
             for v in (elem.attrs) {
                 Some("color") => color ?= v.parse(),
+                Some("draworder") => draw_order ?= v.parse::<DrawOrder>(),
             }
-            color
+            (color, draw_order)
         );
+        let draw_order = draw_order.unwrap_or_default();
         let mut objects = Vec::new();
         let mut properties = HashMap::new();
         parse_tag!(elem, {
@@ -45,7 +99,14 @@ impl ObjectLayerData {
                 Ok(())
             },
         });
-        Ok((ObjectLayerData { objects, colour: c }, properties))
+        Ok((
+            ObjectLayerData {
+                objects,
+                colour: c,
+                draw_order,
+            },
+            properties,
+        ))
     }
 
     /// Returns the data belonging to the objects contained within the layer, in the order they were

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -1,10 +1,9 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::{
-    parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag},
     Color, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader, Result,
-    Tileset,
+    Tileset, parse_properties,
+    util::{get_attrs, map_wrapper, parse_tag},
 };
 
 /// The order in which the objects of an object layer are drawn.
@@ -157,7 +156,7 @@ impl<'map> ObjectLayer<'map> {
     /// # }
     /// ```
     #[inline]
-    pub fn objects(&self) -> impl ExactSizeIterator<Item = Object<'map>> + 'map {
+    pub fn objects(&self) -> impl ExactSizeIterator<Item = Object<'map>> + 'map + use<'map> {
         let map: &'map crate::Map = self.map;
         self.data
             .objects

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -1,12 +1,10 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
-    Color, Error, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader,
-    Result, Tileset,
+    util::{get_attrs, map_wrapper, parse_tag},
+    Color, MapTilesetGid, Object, ObjectData, Properties, ResourceCache, ResourceReader, Result,
+    Tileset,
 };
 
 /// Raw data referring to a map object layer or tile collision data.
@@ -20,9 +18,8 @@ pub struct ObjectLayerData {
 impl ObjectLayerData {
     /// If it is known that there are no objects with tile images in it (i.e. collision data)
     /// then we can pass in [`None`] as the tilesets
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         tilesets: Option<&[MapTilesetGid]>,
         for_tileset: Option<Arc<Tileset>>,
         // path_relative_to is a directory to which all other files are relative to
@@ -31,20 +28,20 @@ impl ObjectLayerData {
         cache: &mut impl ResourceCache,
     ) -> Result<(ObjectLayerData, Properties)> {
         let c = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("color") => color ?= v.parse(),
             }
             color
         );
         let mut objects = Vec::new();
         let mut properties = HashMap::new();
-        parse_tag!(parser, "objectgroup", {
-            "object" => |attrs| {
-                objects.push(ObjectData::new(parser, attrs, tilesets, for_tileset.as_ref().cloned(), path_relative_to, reader, cache)?);
+        parse_tag!(elem, {
+            "object" => |elem| {
+                objects.push(ObjectData::new(elem, tilesets, for_tileset.as_ref().cloned(), path_relative_to, reader, cache)?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -1,7 +1,5 @@
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    util::{get_attrs, map_wrapper, XmlEventResult},
+    util::{get_attrs, map_wrapper},
     LayerTile, LayerTileData, MapTilesetGid, Result,
 };
 
@@ -38,22 +36,21 @@ impl FiniteTileLayerData {
         self.height
     }
 
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         width: u32,
         height: u32,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
-            for v in attrs {
-                Some("encoding") => encoding = v,
-                Some("compression") => compression = v,
+            for v in (elem.attrs) {
+                Some("encoding") => encoding = v.to_string(),
+                Some("compression") => compression = v.to_string(),
             }
             (encoding, compression)
         );
 
-        let tiles = parse_data_line(e, c, parser, tilesets)?;
+        let tiles = parse_data_line(e, c, elem, tilesets)?;
 
         Ok(Self {
             width,

--- a/src/layers/tile/finite.rs
+++ b/src/layers/tile/finite.rs
@@ -1,6 +1,6 @@
 use crate::{
-    util::{get_attrs, map_wrapper},
     LayerTile, LayerTileData, MapTilesetGid, Result,
+    util::{get_attrs, map_wrapper},
 };
 
 use super::util::parse_data_line;

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    util::{floor_div, get_attrs, map_wrapper, parse_tag},
     Error, LayerTile, LayerTileData, MapTilesetGid, Result,
+    util::{floor_div, get_attrs, map_wrapper, parse_tag},
 };
 
 use super::util::parse_data_line;
@@ -263,7 +263,9 @@ impl<'map> InfiniteTileLayer<'map> {
     /// # }
     /// ```
     #[inline]
-    pub fn chunks(&self) -> impl ExactSizeIterator<Item = ((i32, i32), Chunk<'map>)> + 'map {
+    pub fn chunks(
+        &self,
+    ) -> impl ExactSizeIterator<Item = ((i32, i32), Chunk<'map>)> + 'map + use<'map> {
         let map: &'map crate::Map = self.map;
         self.data
             .chunks

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    util::{floor_div, get_attrs, map_wrapper, parse_tag, XmlEventResult},
+    util::{floor_div, get_attrs, map_wrapper, parse_tag},
     Error, LayerTile, LayerTileData, MapTilesetGid, Result,
 };
 
@@ -22,23 +20,22 @@ impl std::fmt::Debug for InfiniteTileLayerData {
 }
 
 impl InfiniteTileLayerData {
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (e, c) = get_attrs!(
-            for v in attrs {
-                Some("encoding") => encoding = v,
-                Some("compression") => compression = v,
+            for v in (elem.attrs) {
+                Some("encoding") => encoding = v.to_string(),
+                Some("compression") => compression = v.to_string(),
             }
             (encoding, compression)
         );
 
         let mut chunks = HashMap::<(i32, i32), ChunkData>::new();
-        parse_tag!(parser, "data", {
-            "chunk" => |attrs| {
-                let chunk = InternalChunk::new(parser, attrs, e.clone(), c.clone(), tilesets)?;
+        parse_tag!(elem, {
+            "chunk" => |elem| {
+                let chunk = InternalChunk::new(elem, e.clone(), c.clone(), tilesets)?;
                 for x in chunk.x..chunk.x + chunk.width as i32 {
                     for y in chunk.y..chunk.y + chunk.height as i32 {
                         let chunk_pos = ChunkData::tile_to_chunk_pos(x, y);
@@ -184,15 +181,14 @@ struct InternalChunk {
 }
 
 impl InternalChunk {
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         encoding: Option<String>,
         compression: Option<String>,
         tilesets: &[MapTilesetGid],
     ) -> Result<Self> {
         let (x, y, width, height) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "x" => x ?= v.parse::<i32>(),
                 "y" => y ?= v.parse::<i32>(),
                 "width" => width ?= v.parse::<u32>(),
@@ -201,7 +197,7 @@ impl InternalChunk {
             (x, y, width, height)
         );
 
-        let tiles = parse_data_line(encoding, compression, parser, tilesets)?;
+        let tiles = parse_data_line(encoding, compression, elem, tilesets)?;
 
         Ok(InternalChunk {
             x,

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     parse_properties,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
-    Error, Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset,
+    util::{get_attrs, map_wrapper, parse_tag},
+    Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset,
 };
 
 mod finite;
@@ -94,14 +92,13 @@ pub(crate) enum TileLayerData {
 }
 
 impl TileLayerData {
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         infinite: bool,
         tilesets: &[MapTilesetGid],
     ) -> Result<(Self, Properties)> {
         let (width, height) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "width" => width ?= v.parse::<u32>(),
                 "height" => height ?= v.parse::<u32>(),
             }
@@ -109,17 +106,17 @@ impl TileLayerData {
         );
         let mut result = Self::Finite(Default::default());
         let mut properties = HashMap::new();
-        parse_tag!(parser, "layer", {
-            "data" => |attrs| {
+        parse_tag!(elem, {
+            "data" => |elem| {
                 if infinite {
-                    result = Self::Infinite(InfiniteTileLayerData::new(parser, attrs, tilesets)?);
+                    result = Self::Infinite(InfiniteTileLayerData::new(elem, tilesets)?);
                 } else {
-                    result = Self::Finite(FiniteTileLayerData::new(parser, attrs, width, height, tilesets)?);
+                    result = Self::Finite(FiniteTileLayerData::new(elem, width, height, tilesets)?);
                 }
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    parse_properties,
+    Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset, parse_properties,
     util::{get_attrs, map_wrapper, parse_tag},
-    Gid, Map, MapTilesetGid, Properties, Result, Tile, TileId, Tileset,
 };
 
 mod finite;

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, io::Read};
 use base64::Engine;
 
 use crate::{
-    util::read_text_or_cdata, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result,
+    CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result, util::read_text_or_cdata,
 };
 
 pub(crate) fn parse_data_line<R: std::io::BufRead>(
@@ -63,7 +63,7 @@ fn decode_csv(text: &str, tilesets: &[MapTilesetGid]) -> Result<Vec<Option<Layer
             Err(e) => {
                 return Err(Error::CsvDecodingError(
                     CsvDecodingError::TileDataParseError(e),
-                ))
+                ));
             }
         }
     }

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -1,56 +1,48 @@
 use std::{convert::TryInto, io::Read};
 
 use base64::Engine;
-use xml::reader::XmlEvent;
 
-use crate::{util::XmlEventResult, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result};
+use crate::{
+    util::read_text_or_cdata, CsvDecodingError, Error, LayerTileData, MapTilesetGid, Result,
+};
 
-pub(crate) fn parse_data_line(
+pub(crate) fn parse_data_line<R: std::io::BufRead>(
     encoding: Option<String>,
     compression: Option<String>,
-    parser: &mut impl Iterator<Item = XmlEventResult>,
+    elem: crate::util::XmlElement<'_, R>,
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>> {
-    match (encoding.as_deref(), compression.as_deref()) {
-        (Some("csv"), None) => decode_csv(parser, tilesets),
+    let encoding_ref = encoding.as_deref();
+    let compression_ref = compression.as_deref();
+    read_text_or_cdata(elem, |text| match (encoding_ref, compression_ref) {
+        (Some("csv"), None) => decode_csv(text, tilesets),
 
-        (Some("base64"), None) => parse_base64(parser).map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("zlib")) => parse_base64(parser)
+        (Some("base64"), None) => parse_base64(text).map(|v| convert_to_tiles(&v, tilesets)),
+        (Some("base64"), Some("zlib")) => parse_base64(text)
             .and_then(|data| process_decoder(Ok(flate2::bufread::ZlibDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
-        (Some("base64"), Some("gzip")) => parse_base64(parser)
+        (Some("base64"), Some("gzip")) => parse_base64(text)
             .and_then(|data| process_decoder(Ok(flate2::bufread::GzDecoder::new(&data[..]))))
             .map(|v| convert_to_tiles(&v, tilesets)),
         #[cfg(feature = "zstd")]
-        (Some("base64"), Some("zstd")) => parse_base64(parser)
+        (Some("base64"), Some("zstd")) => parse_base64(text)
             .and_then(|data| process_decoder(zstd::stream::read::Decoder::with_buffer(&data[..])))
             .map(|v| convert_to_tiles(&v, tilesets)),
 
         _ => Err(Error::InvalidEncodingFormat {
-            encoding,
-            compression,
+            encoding: encoding.clone(),
+            compression: compression.clone(),
         }),
-    }
+    })
 }
 
-fn parse_base64(parser: &mut impl Iterator<Item = XmlEventResult>) -> Result<Vec<u8>> {
-    for next in parser {
-        match next.map_err(Error::XmlDecodingError)? {
-            XmlEvent::Characters(s) => {
-                return base64::engine::GeneralPurpose::new(
-                    &base64::alphabet::STANDARD,
-                    base64::engine::general_purpose::PAD,
-                )
-                .decode(s.trim().as_bytes())
-                .map_err(Error::Base64DecodingError);
-            }
-            XmlEvent::EndElement { name, .. } if name.local_name == "data" => {
-                return Ok(Vec::new());
-            }
-            _ => {}
-        }
-    }
-    Err(Error::PrematureEnd("Ran out of XML data".to_owned()))
+fn parse_base64(text: &str) -> Result<Vec<u8>> {
+    base64::engine::GeneralPurpose::new(
+        &base64::alphabet::STANDARD,
+        base64::engine::general_purpose::PAD,
+    )
+    .decode(text.trim().as_bytes())
+    .map_err(Error::Base64DecodingError)
 }
 
 fn process_decoder(decoder: std::io::Result<impl Read>) -> Result<Vec<u8>> {
@@ -63,33 +55,19 @@ fn process_decoder(decoder: std::io::Result<impl Read>) -> Result<Vec<u8>> {
         .map_err(Error::DecompressingError)
 }
 
-fn decode_csv(
-    parser: &mut impl Iterator<Item = XmlEventResult>,
-    tilesets: &[MapTilesetGid],
-) -> Result<Vec<Option<LayerTileData>>> {
-    for next in parser {
-        match next.map_err(Error::XmlDecodingError)? {
-            XmlEvent::Characters(s) => {
-                let mut tiles = Vec::new();
-                for v in s.split(',') {
-                    match v.trim().parse() {
-                        Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
-                        Err(e) => {
-                            return Err(Error::CsvDecodingError(
-                                CsvDecodingError::TileDataParseError(e),
-                            ))
-                        }
-                    }
-                }
-                return Ok(tiles);
+fn decode_csv(text: &str, tilesets: &[MapTilesetGid]) -> Result<Vec<Option<LayerTileData>>> {
+    let mut tiles = Vec::new();
+    for v in text.split(',') {
+        match v.trim().parse() {
+            Ok(bits) => tiles.push(LayerTileData::from_bits(bits, tilesets)),
+            Err(e) => {
+                return Err(Error::CsvDecodingError(
+                    CsvDecodingError::TileDataParseError(e),
+                ))
             }
-            XmlEvent::EndElement { name, .. } if name.local_name == "data" => {
-                return Ok(Vec::new());
-            }
-            _ => {}
         }
     }
-    Err(Error::PrematureEnd("Ran out of XML data".to_owned()))
+    Ok(tiles)
 }
 
 fn convert_to_tiles(data: &[u8], tilesets: &[MapTilesetGid]) -> Vec<Option<LayerTileData>> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -89,7 +89,7 @@ pub struct Map {
     pub background_color: Option<Color>,
     infinite: bool,
     /// The type of the map, which is arbitrary and set by the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
 }
 
 impl fmt::Debug for Map {
@@ -229,7 +229,7 @@ impl Map {
         );
 
         let infinite = infinite.unwrap_or(false);
-        let user_type = user_type.or(user_class);
+        let user_type = user_type.or(user_class).unwrap_or_default();
         let render_order = render_order.unwrap_or_default();
         let skew_x = skew_x.unwrap_or(0);
         let skew_y = skew_y.unwrap_or(0);

--- a/src/map.rs
+++ b/src/map.rs
@@ -54,6 +54,16 @@ pub struct Map {
     /// individual tiles may have different sizes. As such, there is no guarantee that this value
     /// will be the same as the one from the tilesets the map is using.
     pub tile_height: u32,
+    /// The horizontal skew of the tile grid in pixels (used by oblique maps).
+    ///
+    /// Each row of tiles is shifted horizontally by this amount relative to the row above it,
+    /// resulting in a horizontal shear factor of `skew_x / tile_height`.
+    pub skew_x: i32,
+    /// The vertical skew of the tile grid in pixels (used by oblique maps).
+    ///
+    /// Each column of tiles is shifted vertically by this amount relative to the column to its
+    /// left, resulting in a vertical shear factor of `skew_y / tile_width`.
+    pub skew_y: i32,
     /// The length of the side of a hexagonal tile in pixels (used by tile layers on hexagonal maps).
     pub hex_side_length: Option<i32>,
     /// The stagger axis of Hexagonal/Staggered map.
@@ -82,6 +92,9 @@ impl fmt::Debug for Map {
             .field("height", &self.height)
             .field("tile_width", &self.tile_width)
             .field("tile_height", &self.tile_height)
+            .field("skew_x", &self.skew_x)
+            .field("skew_y", &self.skew_y)
+            .field("hex_side_length", &self.hex_side_length)
             .field("stagger_axis", &self.stagger_axis)
             .field("stagger_index", &self.stagger_index)
             .field("tilesets", &format!("{} tilesets", self.tilesets.len()))
@@ -164,7 +177,17 @@ impl Map {
         cache: &mut impl ResourceCache,
     ) -> Result<Map> {
         let (
-            (c, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length),
+            (
+                c,
+                infinite,
+                user_type,
+                user_class,
+                skew_x,
+                skew_y,
+                stagger_axis,
+                stagger_index,
+                hex_side_length,
+            ),
             (v, o, w, h, tw, th),
         ) = get_attrs!(
             for v in (elem.attrs) {
@@ -172,6 +195,8 @@ impl Map {
                 Some("infinite") => infinite = v == "1",
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
+                Some("skewx") => skew_x ?= v.parse::<i32>(),
+                Some("skewy") => skew_y ?= v.parse::<i32>(),
                 Some("staggeraxis") => stagger_axis ?= v.parse::<StaggerAxis>(),
                 Some("staggerindex") => stagger_index ?= v.parse::<StaggerIndex>(),
                 Some("hexsidelength") => hex_side_length ?= v.parse(),
@@ -182,11 +207,13 @@ impl Map {
                 "tilewidth" => tile_width ?= v.parse::<u32>(),
                 "tileheight" => tile_height ?= v.parse::<u32>(),
             }
-            ((colour, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
+            ((colour, infinite, user_type, user_class, skew_x, skew_y, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
         );
 
         let infinite = infinite.unwrap_or(false);
         let user_type = user_type.or(user_class);
+        let skew_x = skew_x.unwrap_or(0);
+        let skew_y = skew_y.unwrap_or(0);
         let stagger_axis = stagger_axis.unwrap_or_default();
         let stagger_index = stagger_index.unwrap_or_default();
 
@@ -287,6 +314,8 @@ impl Map {
             height: h,
             tile_width: tw,
             tile_height: th,
+            skew_x,
+            skew_y,
             hex_side_length,
             stagger_axis,
             stagger_index,
@@ -388,6 +417,7 @@ pub enum Orientation {
     Isometric,
     Staggered,
     Hexagonal,
+    Oblique,
 }
 
 #[derive(Debug)]
@@ -399,8 +429,8 @@ pub struct OrientationParseError {
 
 impl std::fmt::Display for OrientationParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("failed to parse orientation, valid options are `orthogonal`, `isometric`, `staggered` \
-        and `hexagonal` but got `{}` instead", self.str_found))
+        f.write_fmt(format_args!("failed to parse orientation, valid options are `orthogonal`, `isometric`, `staggered`, \
+        `hexagonal` and `oblique` but got `{}` instead", self.str_found))
     }
 }
 
@@ -415,6 +445,7 @@ impl FromStr for Orientation {
             "isometric" => Ok(Orientation::Isometric),
             "staggered" => Ok(Orientation::Staggered),
             "hexagonal" => Ok(Orientation::Hexagonal),
+            "oblique" => Ok(Orientation::Oblique),
             _ => Err(OrientationParseError {
                 str_found: s.to_owned(),
             }),
@@ -429,6 +460,7 @@ impl fmt::Display for Orientation {
             Orientation::Isometric => write!(f, "isometric"),
             Orientation::Staggered => write!(f, "staggered"),
             Orientation::Hexagonal => write!(f, "hexagonal"),
+            Orientation::Oblique => write!(f, "oblique"),
         }
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -30,6 +30,9 @@ pub struct Map {
     pub source: PathBuf,
     /// The way tiles are laid out in the map.
     pub orientation: Orientation,
+    /// The order in which the tiles of tile layers are rendered (only relevant for orthogonal
+    /// maps).
+    pub render_order: RenderOrder,
     /// Width of the map, in tiles.
     ///
     /// ## Note
@@ -64,6 +67,12 @@ pub struct Map {
     /// Each column of tiles is shifted vertically by this amount relative to the column to its
     /// left, resulting in a vertical shear factor of `skew_y / tile_width`.
     pub skew_y: i32,
+    /// The X coordinate of the parallax origin in pixels, relative to which all layers are
+    /// scrolled by their parallax factor.
+    pub parallax_origin_x: f32,
+    /// The Y coordinate of the parallax origin in pixels, relative to which all layers are
+    /// scrolled by their parallax factor.
+    pub parallax_origin_y: f32,
     /// The length of the side of a hexagonal tile in pixels (used by tile layers on hexagonal maps).
     pub hex_side_length: Option<i32>,
     /// The stagger axis of Hexagonal/Staggered map.
@@ -88,12 +97,15 @@ impl fmt::Debug for Map {
         f.debug_struct("Map")
             .field("version", &self.version)
             .field("orientation", &self.orientation)
+            .field("render_order", &self.render_order)
             .field("width", &self.width)
             .field("height", &self.height)
             .field("tile_width", &self.tile_width)
             .field("tile_height", &self.tile_height)
             .field("skew_x", &self.skew_x)
             .field("skew_y", &self.skew_y)
+            .field("parallax_origin_x", &self.parallax_origin_x)
+            .field("parallax_origin_y", &self.parallax_origin_y)
             .field("hex_side_length", &self.hex_side_length)
             .field("stagger_axis", &self.stagger_axis)
             .field("stagger_index", &self.stagger_index)
@@ -182,8 +194,11 @@ impl Map {
                 infinite,
                 user_type,
                 user_class,
+                render_order,
                 skew_x,
                 skew_y,
+                parallax_origin_x,
+                parallax_origin_y,
                 stagger_axis,
                 stagger_index,
                 hex_side_length,
@@ -195,8 +210,11 @@ impl Map {
                 Some("infinite") => infinite = v == "1",
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
+                Some("renderorder") => render_order ?= v.parse::<RenderOrder>(),
                 Some("skewx") => skew_x ?= v.parse::<i32>(),
                 Some("skewy") => skew_y ?= v.parse::<i32>(),
+                Some("parallaxoriginx") => parallax_origin_x ?= v.parse::<f32>(),
+                Some("parallaxoriginy") => parallax_origin_y ?= v.parse::<f32>(),
                 Some("staggeraxis") => stagger_axis ?= v.parse::<StaggerAxis>(),
                 Some("staggerindex") => stagger_index ?= v.parse::<StaggerIndex>(),
                 Some("hexsidelength") => hex_side_length ?= v.parse(),
@@ -207,13 +225,16 @@ impl Map {
                 "tilewidth" => tile_width ?= v.parse::<u32>(),
                 "tileheight" => tile_height ?= v.parse::<u32>(),
             }
-            ((colour, infinite, user_type, user_class, skew_x, skew_y, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
+            ((colour, infinite, user_type, user_class, render_order, skew_x, skew_y, parallax_origin_x, parallax_origin_y, stagger_axis, stagger_index, hex_side_length), (version, orientation, width, height, tile_width, tile_height))
         );
 
         let infinite = infinite.unwrap_or(false);
         let user_type = user_type.or(user_class);
+        let render_order = render_order.unwrap_or_default();
         let skew_x = skew_x.unwrap_or(0);
         let skew_y = skew_y.unwrap_or(0);
+        let parallax_origin_x = parallax_origin_x.unwrap_or(0.0);
+        let parallax_origin_y = parallax_origin_y.unwrap_or(0.0);
         let stagger_axis = stagger_axis.unwrap_or_default();
         let stagger_index = stagger_index.unwrap_or_default();
 
@@ -310,12 +331,15 @@ impl Map {
             version: v,
             source: map_path.to_owned(),
             orientation: o,
+            render_order,
             width: w,
             height: h,
             tile_width: tw,
             tile_height: th,
             skew_x,
             skew_y,
+            parallax_origin_x,
+            parallax_origin_y,
             hex_side_length,
             stagger_axis,
             stagger_index,
@@ -405,6 +429,61 @@ impl FromStr for StaggerAxis {
             _ => Err(StaggerAxisError {
                 str_found: s.to_owned(),
             }),
+        }
+    }
+}
+
+/// The order in which the tiles of tile layers are rendered. In all cases, the map is drawn
+/// row-by-row. Only relevant for orthogonal maps.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+#[allow(missing_docs)]
+pub enum RenderOrder {
+    #[default]
+    RightDown,
+    RightUp,
+    LeftDown,
+    LeftUp,
+}
+
+#[derive(Debug)]
+/// An error arising from trying to parse a [`RenderOrder`] that is not valid.
+pub struct RenderOrderParseError {
+    /// The invalid string found.
+    pub str_found: String,
+}
+
+impl std::fmt::Display for RenderOrderParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "failed to parse render order, valid options are `right-down`, `right-up`, \
+        `left-down` and `left-up` but got `{}` instead",
+            self.str_found
+        ))
+    }
+}
+
+impl FromStr for RenderOrder {
+    type Err = RenderOrderParseError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "right-down" => Ok(RenderOrder::RightDown),
+            "right-up" => Ok(RenderOrder::RightUp),
+            "left-down" => Ok(RenderOrder::LeftDown),
+            "left-up" => Ok(RenderOrder::LeftUp),
+            _ => Err(RenderOrderParseError {
+                str_found: s.to_owned(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for RenderOrder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenderOrder::RightDown => write!(f, "right-down"),
+            RenderOrder::RightUp => write!(f, "right-up"),
+            RenderOrder::LeftDown => write!(f, "left-down"),
+            RenderOrder::LeftUp => write!(f, "left-up"),
         }
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -8,14 +8,12 @@ use std::{
     sync::Arc,
 };
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::{Error, Result},
+    error::Result,
     layers::{LayerData, LayerTag},
     properties::{parse_properties, Color, Properties},
     tileset::Tileset,
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
     EmbeddedParseResultType, Layer, ResourceCache, ResourceReader,
 };
 
@@ -159,9 +157,8 @@ impl Map {
 }
 
 impl Map {
-    pub(crate) fn parse_xml(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn parse_xml<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         map_path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -170,7 +167,7 @@ impl Map {
             (c, infinite, user_type, user_class, stagger_axis, stagger_index, hex_side_length),
             (v, o, w, h, tw, th),
         ) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("backgroundcolor") => colour ?= v.parse(),
                 Some("infinite") => infinite = v == "1",
                 Some("type") => user_type ?= v.parse(),
@@ -178,7 +175,7 @@ impl Map {
                 Some("staggeraxis") => stagger_axis ?= v.parse::<StaggerAxis>(),
                 Some("staggerindex") => stagger_index ?= v.parse::<StaggerIndex>(),
                 Some("hexsidelength") => hex_side_length ?= v.parse(),
-                "version" => version = v,
+                "version" => version = v.to_string(),
                 "orientation" => orientation ?= v.parse::<Orientation>(),
                 "width" => width ?= v.parse::<u32>(),
                 "height" => height ?= v.parse::<u32>(),
@@ -200,9 +197,9 @@ impl Map {
         let mut properties = HashMap::new();
         let mut tilesets = Vec::new();
 
-        parse_tag!(parser, "map", {
-            "tileset" => |attrs: Vec<OwnedAttribute>| {
-                let res = Tileset::parse_xml_in_map(parser, &attrs, map_path,  reader, cache)?;
+        parse_tag!(elem, {
+            "tileset" => |elem| {
+                let res = Tileset::parse_xml_in_map(elem, map_path, reader, cache)?;
                 match res.result_type {
                     EmbeddedParseResultType::ExternalReference { tileset_path } => {
                         let tileset = if let Some(ts) = cache.get_tileset(&tileset_path) {
@@ -221,10 +218,9 @@ impl Map {
                 };
                 Ok(())
             },
-            "layer" => |attrs| {
+            "layer" => |elem| {
                 layers.push(LayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     LayerTag::Tiles,
                     infinite,
                     map_path,
@@ -235,10 +231,9 @@ impl Map {
                 )?);
                 Ok(())
             },
-            "imagelayer" => |attrs| {
+            "imagelayer" => |elem| {
                 layers.push(LayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     LayerTag::Image,
                     infinite,
                     map_path,
@@ -249,10 +244,9 @@ impl Map {
                 )?);
                 Ok(())
             },
-            "objectgroup" => |attrs| {
+            "objectgroup" => |elem| {
                 layers.push(LayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     LayerTag::Objects,
                     infinite,
                     map_path,
@@ -263,10 +257,9 @@ impl Map {
                 )?);
                 Ok(())
             },
-            "group" => |attrs| {
+            "group" => |elem| {
                 layers.push(LayerData::new(
-                    parser,
-                    attrs,
+                    elem,
                     LayerTag::Group,
                     infinite,
                     map_path,
@@ -277,8 +270,8 @@ impl Map {
                 )?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/map.rs
+++ b/src/map.rs
@@ -9,12 +9,12 @@ use std::{
 };
 
 use crate::{
+    EmbeddedParseResultType, Layer, ResourceCache, ResourceReader,
     error::Result,
     layers::{LayerData, LayerTag},
-    properties::{parse_properties, Color, Properties},
+    properties::{Color, Properties, parse_properties},
     tileset::Tileset,
     util::{get_attrs, parse_tag},
-    EmbeddedParseResultType, Layer, ResourceCache, ResourceReader,
 };
 
 pub(crate) struct MapTilesetGid {
@@ -171,12 +171,12 @@ impl Map {
     /// # }
     /// ```
     #[inline]
-    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer> {
+    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'_>> {
         self.layers.iter().map(move |layer| Layer::new(self, layer))
     }
 
     /// Returns the top-level layer that has the specified index, if it exists.
-    pub fn get_layer(&self, index: usize) -> Option<Layer> {
+    pub fn get_layer(&self, index: usize) -> Option<Layer<'_>> {
         self.layers.get(index).map(|data| Layer::new(self, data))
     }
 }
@@ -261,7 +261,7 @@ impl Map {
                         tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset});
                     }
                     EmbeddedParseResultType::Embedded { tileset } => {
-                        tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset: Arc::new(tileset)});
+                        tilesets.push(MapTilesetGid{first_gid: res.first_gid, tileset: Arc::new(*tileset)});
                     },
                 };
                 Ok(())

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,12 +1,10 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     error::{Error, Result},
     properties::{parse_properties, Properties},
     template::Template,
-    util::{get_attrs, map_wrapper, parse_tag, XmlEventResult},
+    util::{get_attrs, map_wrapper, parse_tag, read_text_or_cdata},
     Color, Gid, MapTilesetGid, ResourceCache, ResourceReader, Tile, TileId, Tileset,
 };
 
@@ -219,9 +217,8 @@ impl ObjectData {
 impl ObjectData {
     /// If it is known that the object has no tile images in it (i.e. collision data)
     /// then we can pass in [`None`] as the tilesets
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         tilesets: Option<&[MapTilesetGid]>,
         for_tileset: Option<Arc<Tileset>>,
         // Base path is a directory to which all other files are relative to
@@ -230,7 +227,7 @@ impl ObjectData {
         cache: &mut impl ResourceCache,
     ) -> Result<ObjectData> {
         let (id, tile, mut n, mut t, c, mut w, mut h, mut v, mut r, template, x, y) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("id") => id ?= v.parse(),
                 Some("gid") => tile ?= v.parse::<u32>(),
                 Some("name") => name ?= v.parse(),
@@ -298,32 +295,34 @@ impl ObjectData {
         let mut shape = None;
         let mut properties = HashMap::new();
 
-        parse_tag!(parser, "object", {
-            "ellipse" => |_| {
+        parse_tag!(elem, {
+            "ellipse" => |elem: crate::util::XmlElement<'_, R>| {
                 shape = Some(ObjectShape::Ellipse {
                     width,
                     height,
                 });
+                parse_tag!(elem, {});
                 Ok(())
             },
-            "polyline" => |attrs| {
-                shape = Some(ObjectData::new_polyline(attrs)?);
+            "polyline" => |elem| {
+                shape = Some(ObjectData::new_polyline(elem)?);
                 Ok(())
             },
-            "polygon" => |attrs| {
-                shape = Some(ObjectData::new_polygon(attrs)?);
+            "polygon" => |elem| {
+                shape = Some(ObjectData::new_polygon(elem)?);
                 Ok(())
             },
-            "point" => |_| {
+            "point" => |elem: crate::util::XmlElement<'_, R>| {
                 shape = Some(ObjectShape::Point(x, y));
+                parse_tag!(elem, {});
                 Ok(())
             },
-            "text" => |attrs| {
-                shape = Some(ObjectData::new_text(attrs, parser, width, height)?);
+            "text" => |elem| {
+                shape = Some(ObjectData::new_text(elem, width, height)?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });
@@ -398,29 +397,34 @@ impl ObjectData {
 }
 
 impl ObjectData {
-    fn new_polyline(attrs: Vec<OwnedAttribute>) -> Result<ObjectShape> {
+    fn new_polyline<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
+    ) -> Result<ObjectShape> {
         let points = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "points" => points ?= ObjectData::parse_points(v),
             }
             points
         );
+        parse_tag!(elem, {});
         Ok(ObjectShape::Polyline { points })
     }
 
-    fn new_polygon(attrs: Vec<OwnedAttribute>) -> Result<ObjectShape> {
+    fn new_polygon<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
+    ) -> Result<ObjectShape> {
         let points = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "points" => points ?= ObjectData::parse_points(v),
             }
             points
         );
+        parse_tag!(elem, {});
         Ok(ObjectShape::Polygon { points })
     }
 
-    fn new_text(
-        attrs: Vec<OwnedAttribute>,
-        parser: &mut impl Iterator<Item = XmlEventResult>,
+    fn new_text<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         width: f32,
         height: f32,
     ) -> Result<ObjectShape> {
@@ -437,8 +441,8 @@ impl ObjectData {
             halign,
             valign,
         ) = get_attrs!(
-            for v in attrs {
-                Some("fontfamily") => font_family = v,
+            for v in (elem.attrs) {
+                Some("fontfamily") => font_family = v.to_string(),
                 Some("pixelsize") => pixel_size ?= v.parse(),
                 Some("wrap") => wrap ?= v.parse(),
                 Some("color") => color ?= v.parse(),
@@ -447,14 +451,14 @@ impl ObjectData {
                 Some("underline") => underline ?= v.parse(),
                 Some("strikeout") => strikeout ?= v.parse(),
                 Some("kerning") => kerning ?= v.parse::<i32>(),
-                Some("halign") => halign = match v.as_str() {
+                Some("halign") => halign = match v {
                     "left" => HorizontalAlignment::Left,
                     "center" => HorizontalAlignment::Center,
                     "right" => HorizontalAlignment::Right,
                     "justify" => HorizontalAlignment::Justify,
                     _ => return Err(Error::MalformedAttributes("`halign` property did not contain a valid value of 'left', 'center', 'right' or 'justify'".to_string()))
                 },
-                Some("valign") => valign = match v.as_str() {
+                Some("valign") => valign = match v {
                     "top" => VerticalAlignment::Top,
                     "center" => VerticalAlignment::Center,
                     "bottom" => VerticalAlignment::Bottom,
@@ -494,22 +498,7 @@ impl ObjectData {
         let kerning = kerning.map_or(true, |k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
-        let contents = match parser.next().map_or_else(
-            || {
-                Err(Error::PrematureEnd(
-                    "XML stream ended when trying to parse text contents".to_owned(),
-                ))
-            },
-            |r| r.map_err(Error::XmlDecodingError),
-        )? {
-            xml::reader::XmlEvent::Characters(contents) => contents,
-            _ => {
-                return Err(Error::InvalidObjectData {
-                    description: "Text attribute contained anything but characters as content"
-                        .into(),
-                })
-            }
-        };
+        let contents = read_text_or_cdata(elem, |text| Ok(text.to_string()))?;
 
         Ok(ObjectShape::Text {
             font_family,
@@ -529,7 +518,7 @@ impl ObjectData {
         })
     }
 
-    fn parse_points(s: String) -> Result<Vec<(f32, f32)>> {
+    fn parse_points(s: &str) -> Result<Vec<(f32, f32)>> {
         let pairs = s.split(' ');
         pairs
             .map(|point| point.split(','))

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::{
+    Color, Gid, MapTilesetGid, ResourceCache, ResourceReader, Tile, TileId, Tileset,
     error::{Error, Result},
-    properties::{parse_properties, Properties},
+    properties::{Properties, parse_properties},
     template::Template,
     util::{get_attrs, map_wrapper, parse_tag, read_text_or_cdata},
-    Color, Gid, MapTilesetGid, ResourceCache, ResourceReader, Tile, TileId, Tileset,
 };
 
 /// The location of the tileset this tile is in
@@ -383,16 +383,16 @@ impl ObjectData {
                         height: _,
                     } => ObjectShape::Text {
                         font_family: font_family.clone(),
-                        pixel_size: pixel_size.clone(),
-                        wrap: wrap.clone(),
-                        color: color.clone(),
-                        bold: bold.clone(),
-                        italic: italic.clone(),
-                        underline: underline.clone(),
-                        strikeout: strikeout.clone(),
-                        kerning: kerning.clone(),
-                        halign: halign.clone(),
-                        valign: valign.clone(),
+                        pixel_size: *pixel_size,
+                        wrap: *wrap,
+                        color: *color,
+                        bold: *bold,
+                        italic: *italic,
+                        underline: *underline,
+                        strikeout: *strikeout,
+                        kerning: *kerning,
+                        halign: *halign,
+                        valign: *valign,
                         text: text.clone(),
                         width,
                         height,
@@ -527,7 +527,7 @@ impl ObjectData {
         let italic = italic == Some(1);
         let underline = underline == Some(1);
         let strikeout = strikeout == Some(1);
-        let kerning = kerning.map_or(true, |k| k == 1);
+        let kerning = kerning.is_none_or(|k| k == 1);
         let halign = halign.unwrap_or_default();
         let valign = valign.unwrap_or_default();
         let contents = read_text_or_cdata(elem, |text| Ok(text.to_string()))?;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -126,6 +126,10 @@ pub enum ObjectShape {
         width: f32,
         height: f32,
     },
+    Capsule {
+        width: f32,
+        height: f32,
+    },
     Polyline {
         points: Vec<(f32, f32)>,
     },
@@ -190,6 +194,8 @@ pub struct ObjectData {
     pub y: f32,
     /// The clockwise rotation of this object around (x,y) in degrees.
     pub rotation: f32,
+    /// The opacity of this object.
+    pub opacity: f32,
     /// Whether the object is shown or hidden.
     pub visible: bool,
     /// The object's shape.
@@ -226,7 +232,7 @@ impl ObjectData {
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<ObjectData> {
-        let (id, tile, mut n, mut t, c, mut w, mut h, mut v, mut r, template, x, y) = get_attrs!(
+        let (id, tile, mut n, mut t, c, mut w, mut h, mut v, mut r, mut o, template, x, y) = get_attrs!(
             for v in (elem.attrs) {
                 Some("id") => id ?= v.parse(),
                 Some("gid") => tile ?= v.parse::<u32>(),
@@ -237,11 +243,12 @@ impl ObjectData {
                 Some("height") => height ?= v.parse(),
                 Some("visible") => visible ?= v.parse().map(|x:i32| x == 1),
                 Some("rotation") => rotation ?= v.parse(),
+                Some("opacity") => opacity ?= v.parse(),
                 Some("template") => template ?= v.parse(),
                 Some("x") => x ?= v.parse::<f32>(),
                 Some("y") => y ?= v.parse::<f32>(),
             }
-            (id, tile, name, user_type, user_class, width, height, visible, rotation, template, x, y)
+            (id, tile, name, user_type, user_class, width, height, visible, rotation, opacity, template, x, y)
         );
         let x = x.unwrap_or(0.);
         let y = y.unwrap_or(0.);
@@ -267,6 +274,7 @@ impl ObjectData {
                 let obj = &template.object;
                 v.get_or_insert(obj.visible);
                 r.get_or_insert(obj.rotation);
+                o.get_or_insert(obj.opacity);
                 n.get_or_insert_with(|| obj.name.clone());
                 t.get_or_insert_with(|| obj.user_type.clone());
                 if let Some(templ_tile) = &obj.tile {
@@ -275,6 +283,7 @@ impl ObjectData {
                 match &obj.shape {
                     ObjectShape::Rect { width, height }
                     | ObjectShape::Ellipse { width, height }
+                    | ObjectShape::Capsule { width, height }
                     | ObjectShape::Text { width, height, .. } => {
                         w.get_or_insert(*width);
                         h.get_or_insert(*height);
@@ -289,6 +298,7 @@ impl ObjectData {
         let width = w.unwrap_or(0f32);
         let height = h.unwrap_or(0f32);
         let rotation = r.unwrap_or(0f32);
+        let opacity = o.unwrap_or(1f32);
         let id = id.unwrap_or(0u32);
         let name = n.unwrap_or_default();
         let user_type: String = t.or(c).unwrap_or_default();
@@ -298,6 +308,14 @@ impl ObjectData {
         parse_tag!(elem, {
             "ellipse" => |elem: crate::util::XmlElement<'_, R>| {
                 shape = Some(ObjectShape::Ellipse {
+                    width,
+                    height,
+                });
+                parse_tag!(elem, {});
+                Ok(())
+            },
+            "capsule" => |elem: crate::util::XmlElement<'_, R>| {
+                shape = Some(ObjectShape::Capsule {
                     width,
                     height,
                 });
@@ -334,6 +352,7 @@ impl ObjectData {
                 match &templ.object.shape {
                     ObjectShape::Rect { .. } => ObjectShape::Rect { width, height },
                     ObjectShape::Ellipse { .. } => ObjectShape::Ellipse { width, height },
+                    ObjectShape::Capsule { .. } => ObjectShape::Capsule { width, height },
                     ObjectShape::Point(_, _) => ObjectShape::Point(x, y),
                     ObjectShape::Text {
                         font_family,
@@ -389,6 +408,7 @@ impl ObjectData {
             x,
             y,
             rotation,
+            opacity,
             visible,
             shape,
             properties,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -136,7 +136,15 @@ pub enum ObjectShape {
     Polygon {
         points: Vec<(f32, f32)>,
     },
-    Point(f32, f32),
+    /// A point marker.
+    ///
+    /// The values are deprecated, since they merely duplicate the object's `x` and `y` members
+    /// and will be removed in a future version. Match this variant with
+    /// `ObjectShape::Point(..)` to avoid the deprecation warnings.
+    Point(
+        #[deprecated = "use the object's `x` member instead"] f32,
+        #[deprecated = "use the object's `y` member instead"] f32,
+    ),
     Text {
         font_family: String,
         pixel_size: usize,
@@ -331,7 +339,10 @@ impl ObjectData {
                 Ok(())
             },
             "point" => |elem: crate::util::XmlElement<'_, R>| {
-                shape = Some(ObjectShape::Point(x, y));
+                #[allow(deprecated)]
+                {
+                    shape = Some(ObjectShape::Point(x, y));
+                }
                 parse_tag!(elem, {});
                 Ok(())
             },
@@ -353,7 +364,8 @@ impl ObjectData {
                     ObjectShape::Rect { .. } => ObjectShape::Rect { width, height },
                     ObjectShape::Ellipse { .. } => ObjectShape::Ellipse { width, height },
                     ObjectShape::Capsule { .. } => ObjectShape::Capsule { width, height },
-                    ObjectShape::Point(_, _) => ObjectShape::Point(x, y),
+                    #[allow(deprecated)]
+                    ObjectShape::Point(..) => ObjectShape::Point(x, y),
                     ObjectShape::Text {
                         font_family,
                         pixel_size,

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -1,44 +1,23 @@
+use std::io::BufReader;
 use std::path::Path;
 
-use xml::{reader::XmlEvent, EventReader};
+use quick_xml::Reader;
 
-use crate::{Error, Map, ResourceCache, ResourceReader, Result};
+use crate::{util::parse_root_element, Error, Map, ResourceCache, ResourceReader, Result};
 
 pub fn parse_map(
     path: &Path,
     reader: &mut impl ResourceReader,
     cache: &mut impl ResourceCache,
 ) -> Result<Map> {
-    let mut parser =
-        EventReader::new(
-            reader
-                .read_from(path)
-                .map_err(|err| Error::ResourceLoadingError {
-                    path: path.to_owned(),
-                    err: Box::new(err),
-                })?,
-        );
-    loop {
-        match parser.next().map_err(Error::XmlDecodingError)? {
-            XmlEvent::StartElement {
-                name, attributes, ..
-            } => {
-                if name.local_name == "map" {
-                    return Map::parse_xml(
-                        &mut parser.into_iter(),
-                        attributes,
-                        path,
-                        reader,
-                        cache,
-                    );
-                }
-            }
-            XmlEvent::EndDocument => {
-                return Err(Error::PrematureEnd(
-                    "Document ended before map was parsed".to_string(),
-                ))
-            }
-            _ => {}
-        }
-    }
+    let file = reader
+        .read_from(path)
+        .map_err(|err| Error::ResourceLoadingError {
+            path: path.to_owned(),
+            err: Box::new(err),
+        })?;
+    let mut parser = Reader::from_reader(BufReader::new(file));
+    parse_root_element(&mut parser, b"map", |elem| {
+        Map::parse_xml(elem, path, reader, cache)
+    })
 }

--- a/src/parse/xml/map.rs
+++ b/src/parse/xml/map.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use quick_xml::Reader;
 
-use crate::{util::parse_root_element, Error, Map, ResourceCache, ResourceReader, Result};
+use crate::{Error, Map, ResourceCache, ResourceReader, Result, util::parse_root_element};
 
 pub fn parse_map(
     path: &Path,

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -1,42 +1,23 @@
+use std::io::BufReader;
 use std::path::Path;
 
-use xml::{reader::XmlEvent, EventReader};
+use quick_xml::Reader;
 
-use crate::{Error, ResourceCache, ResourceReader, Result, Tileset};
+use crate::{util::parse_root_element, Error, ResourceCache, ResourceReader, Result, Tileset};
 
 pub fn parse_tileset(
     path: &Path,
     reader: &mut impl ResourceReader,
     cache: &mut impl ResourceCache,
 ) -> Result<Tileset> {
-    let mut tileset_parser =
-        EventReader::new(
-            reader
-                .read_from(path)
-                .map_err(|err| Error::ResourceLoadingError {
-                    path: path.to_owned(),
-                    err: Box::new(err),
-                })?,
-        );
-    loop {
-        match tileset_parser.next().map_err(Error::XmlDecodingError)? {
-            XmlEvent::StartElement {
-                name, attributes, ..
-            } if name.local_name == "tileset" => {
-                return Tileset::parse_external_tileset(
-                    &mut tileset_parser.into_iter(),
-                    &attributes,
-                    path,
-                    reader,
-                    cache,
-                );
-            }
-            XmlEvent::EndDocument => {
-                return Err(Error::PrematureEnd(
-                    "Tileset Document ended before map was parsed".to_string(),
-                ))
-            }
-            _ => {}
-        }
-    }
+    let file = reader
+        .read_from(path)
+        .map_err(|err| Error::ResourceLoadingError {
+            path: path.to_owned(),
+            err: Box::new(err),
+        })?;
+    let mut tileset_parser = Reader::from_reader(BufReader::new(file));
+    parse_root_element(&mut tileset_parser, b"tileset", |elem| {
+        Tileset::parse_external_tileset(elem, path, reader, cache)
+    })
 }

--- a/src/parse/xml/tileset.rs
+++ b/src/parse/xml/tileset.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use quick_xml::Reader;
 
-use crate::{util::parse_root_element, Error, ResourceCache, ResourceReader, Result, Tileset};
+use crate::{Error, ResourceCache, ResourceReader, Result, Tileset, util::parse_root_element};
 
 pub fn parse_tileset(
     path: &Path,

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,10 +1,8 @@
 use std::{collections::HashMap, str::FromStr};
 
-use xml::{attribute::OwnedAttribute, reader::XmlEvent};
-
 use crate::{
     error::{Error, Result},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag, read_text_or_cdata},
 };
 
 /// Represents a RGBA color with 8-bit depth on each channel.
@@ -137,31 +135,30 @@ impl PropertyValue {
 /// A custom property container.
 pub type Properties = HashMap<String, PropertyValue>;
 
-pub(crate) fn parse_properties(
-    parser: &mut impl Iterator<Item = XmlEventResult>,
+pub(crate) fn parse_properties<R: std::io::BufRead>(
+    elem: crate::util::XmlElement<'_, R>,
 ) -> Result<Properties> {
     let mut p = HashMap::new();
-    parse_tag!(parser, "properties", {
-        "property" => |attrs:Vec<OwnedAttribute>| {
+    parse_tag!(elem, {
+        "property" => |elem: crate::util::XmlElement<'_, R>| {
             let (t, v_attr, k, p_t) = get_attrs!(
-                for attr in attrs {
-                    Some("type") => obj_type = attr,
-                    Some("value") => value = attr,
-                    Some("propertytype") => propertytype = attr,
-                    "name" => name = attr
+                for attr in (elem.attrs) {
+                    Some("type") => obj_type = attr.to_string(),
+                    Some("value") => value = attr.to_string(),
+                    Some("propertytype") => propertytype = attr.to_string(),
+                    "name" => name = attr.to_string()
                 }
                 (obj_type, value, name, propertytype)
             );
             let t = t.unwrap_or_else(|| "string".to_owned());
             if t == "class" {
-                // Class properties will have their member values stored in a nested <properties>
-                // element. Only the actually set members are saved. When no members have been set
-                // the properties element is left out entirely.
-                let properties = if has_properties_tag_next(parser) {
-                    parse_properties(parser)?
-                } else {
-                    HashMap::new()
-                };
+                let mut properties = HashMap::new();
+                parse_tag!(elem, {
+                    "properties" => |elem| {
+                        properties = parse_properties(elem)?;
+                        Ok(())
+                    },
+                });
                 p.insert(k, PropertyValue::ClassValue {
                     property_type: p_t.unwrap_or_default(),
                     properties,
@@ -170,44 +167,21 @@ pub(crate) fn parse_properties(
             }
 
             let v: String = match v_attr {
-                Some(val) => val,
+                Some(val) => {
+                    parse_tag!(elem, {});
+                    val
+                }
                 None => {
                     // if the "value" attribute was missing, might be a multiline string
-                    match parser.next() {
-                        Some(Ok(XmlEvent::Characters(s))) => Ok(s),
-                        Some(Err(err)) => Err(Error::XmlDecodingError(err)),
-                        None => unreachable!(), // EndDocument or error must come first
-                        _ => Err(Error::MalformedAttributes(format!("property '{}' is missing a value", k))),
-                    }?
+                    read_text_or_cdata(
+                        elem,
+                        |text| Ok(text.to_string()),
+                    )?
                 }
             };
-
             p.insert(k, PropertyValue::new(t, v)?);
             Ok(())
         },
     });
     Ok(p)
-}
-
-/// Checks if there is a properties tag next in the parser. Will consume any whitespace or comments.
-fn has_properties_tag_next(parser: &mut impl Iterator<Item = XmlEventResult>) -> bool {
-    let mut peekable = parser.by_ref().peekable();
-    while let Some(Ok(next)) = peekable.peek() {
-        match next {
-            XmlEvent::StartElement { name, .. } if name.local_name == "properties" => return true,
-            // Ignore whitespace and comments
-            XmlEvent::Whitespace(_) => {
-                peekable.next();
-            }
-            XmlEvent::Comment(_) => {
-                peekable.next();
-            }
-            // If we encounter anything else than whitespace, comments or the properties tag, we
-            // assume there are no properties.
-            _ => {
-                return false;
-            }
-        }
-    }
-    false
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -80,6 +80,8 @@ pub enum PropertyValue {
     /// An object ID value. Corresponds to the `object` property type.
     /// Holds the id of a referenced object, or 0 if unset.
     ObjectValue(u32),
+    /// A list of property values. Corresponds to the `list` property type.
+    ListValue(Vec<PropertyValue>),
     /// A class value. Corresponds to the `class` property type.
     /// Holds the type name and a set of properties.
     ClassValue {
@@ -150,38 +152,69 @@ pub(crate) fn parse_properties<R: std::io::BufRead>(
                 }
                 (obj_type, value, name, propertytype)
             );
-            let t = t.unwrap_or_else(|| "string".to_owned());
-            if t == "class" {
-                let mut properties = HashMap::new();
-                parse_tag!(elem, {
-                    "properties" => |elem| {
-                        properties = parse_properties(elem)?;
-                        Ok(())
-                    },
-                });
-                p.insert(k, PropertyValue::ClassValue {
-                    property_type: p_t.unwrap_or_default(),
-                    properties,
-                });
-                return Ok(());
-            }
-
-            let v: String = match v_attr {
-                Some(val) => {
-                    parse_tag!(elem, {});
-                    val
-                }
-                None => {
-                    // if the "value" attribute was missing, might be a multiline string
-                    read_text_or_cdata(
-                        elem,
-                        |text| Ok(text.to_string()),
-                    )?
-                }
-            };
-            p.insert(k, PropertyValue::new(t, v)?);
+            p.insert(k, parse_property_value(elem, t, v_attr, p_t)?);
             Ok(())
         },
     });
     Ok(p)
+}
+
+/// Parses the value of a `<property>` or list `<item>` element, given its `type`, `value` and
+/// `propertytype` attributes. Consumes the element's content.
+fn parse_property_value<R: std::io::BufRead>(
+    elem: crate::util::XmlElement<'_, R>,
+    t: Option<String>,
+    v_attr: Option<String>,
+    p_t: Option<String>,
+) -> Result<PropertyValue> {
+    let t = t.unwrap_or_else(|| "string".to_owned());
+    if t == "class" {
+        // Class properties will have their member values stored in a nested <properties>
+        // element. Only the actually set members are saved. When no members have been set
+        // the properties element is left out entirely.
+        let mut properties = HashMap::new();
+        parse_tag!(elem, {
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
+                Ok(())
+            },
+        });
+        return Ok(PropertyValue::ClassValue {
+            property_type: p_t.unwrap_or_default(),
+            properties,
+        });
+    }
+
+    if t == "list" {
+        // List properties store each of their values in a nested <item> element, which is
+        // structured like a <property> element without a name.
+        let mut items = Vec::new();
+        parse_tag!(elem, {
+            "item" => |elem: crate::util::XmlElement<'_, R>| {
+                let (t, v_attr, p_t) = get_attrs!(
+                    for attr in (elem.attrs) {
+                        Some("type") => obj_type = attr.to_string(),
+                        Some("value") => value = attr.to_string(),
+                        Some("propertytype") => propertytype = attr.to_string(),
+                    }
+                    (obj_type, value, propertytype)
+                );
+                items.push(parse_property_value(elem, t, v_attr, p_t)?);
+                Ok(())
+            },
+        });
+        return Ok(PropertyValue::ListValue(items));
+    }
+
+    let v: String = match v_attr {
+        Some(val) => {
+            parse_tag!(elem, {});
+            val
+        }
+        None => {
+            // if the "value" attribute was missing, might be a multiline string
+            read_text_or_cdata(elem, |text| Ok(text.to_string()))?
+        }
+    };
+    PropertyValue::new(t, v)
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -48,6 +48,12 @@ impl FilesystemResourceReader {
     }
 }
 
+impl Default for FilesystemResourceReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ResourceReader for FilesystemResourceReader {
     type Resource = BufReader<File>;
     type Error = std::io::Error;

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use quick_xml::Reader;
 
 use crate::{
-    util::{parse_root_element, parse_tag, XmlElement},
     EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache, ResourceReader,
     Result, Tileset,
+    util::{XmlElement, parse_root_element, parse_tag},
 };
 
 /// A template, consisting of an object and a tileset
@@ -72,7 +72,7 @@ impl Template {
                         });
                     }
                     EmbeddedParseResultType::Embedded { tileset: embedded_tileset } => {
-                        tileset = Some(Arc::new(embedded_tileset));
+                        tileset = Some(Arc::new(*embedded_tileset));
                     },
                 };
                 tileset_gid.push(MapTilesetGid {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,12 +1,13 @@
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use xml::EventReader;
-use xml::{attribute::OwnedAttribute, reader::XmlEvent};
+use quick_xml::Reader;
 
 use crate::{
-    util::*, EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache,
-    ResourceReader, Result, Tileset,
+    util::{parse_root_element, parse_tag, XmlElement},
+    EmbeddedParseResultType, Error, MapTilesetGid, ObjectData, ResourceCache, ResourceReader,
+    Result, Tileset,
 };
 
 /// A template, consisting of an object and a tileset
@@ -37,34 +38,14 @@ impl Template {
                 err: Box::new(err),
             })?;
 
-        let mut template_parser = EventReader::new(file);
-        loop {
-            match template_parser.next().map_err(Error::XmlDecodingError)? {
-                XmlEvent::StartElement {
-                    name,
-                    attributes: _,
-                    ..
-                } if name.local_name == "template" => {
-                    let template = Self::parse_external_template(
-                        &mut template_parser.into_iter(),
-                        path,
-                        reader,
-                        cache,
-                    )?;
-                    return Ok(template);
-                }
-                XmlEvent::EndDocument => {
-                    return Err(Error::PrematureEnd(
-                        "Template Document ended before template element was parsed".to_string(),
-                    ))
-                }
-                _ => {}
-            }
-        }
+        let mut template_parser = Reader::from_reader(BufReader::new(file));
+        parse_root_element(&mut template_parser, b"template", |elem| {
+            Self::parse_external_template(elem, path, reader, cache)
+        })
     }
 
-    fn parse_external_template(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
+    fn parse_external_template<R: std::io::BufRead>(
+        elem: XmlElement<'_, R>,
         template_path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -73,13 +54,13 @@ impl Template {
         let mut tileset = None;
         let mut tileset_gid: Vec<MapTilesetGid> = vec![];
 
-        parse_tag!(parser, "template", {
-            "object" => |attrs| {
-                object = Some(ObjectData::new(parser, attrs, Some(&tileset_gid), tileset.clone(), template_path.parent().ok_or(Error::PathIsNotFile)?, reader, cache)?);
+        parse_tag!(elem, {
+            "object" => |elem| {
+                object = Some(ObjectData::new(elem, Some(&tileset_gid), tileset.clone(), template_path.parent().ok_or(Error::PathIsNotFile)?, reader, cache)?);
                 Ok(())
             },
-            "tileset" => |attrs: Vec<OwnedAttribute>| {
-                let res = Tileset::parse_xml_in_map(parser, &attrs, template_path, reader, cache)?;
+            "tileset" => |elem| {
+                let res = Tileset::parse_xml_in_map(elem, template_path, reader, cache)?;
                 match res.result_type {
                     EmbeddedParseResultType::ExternalReference { tileset_path } => {
                         tileset = Some(if let Some(ts) = cache.get_tileset(&tileset_path) {

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,14 +1,11 @@
 use std::{collections::HashMap, path::Path};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     animation::{parse_animation, Frame},
-    error::Error,
     image::Image,
     layers::ObjectLayerData,
     properties::{parse_properties, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
     ResourceCache, ResourceReader, Result, Tileset,
 };
 
@@ -77,15 +74,14 @@ impl<'tileset> std::ops::Deref for Tile<'tileset> {
 }
 
 impl TileData {
-    pub(crate) fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         path_relative_to: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<(TileId, TileData)> {
         let ((user_type, user_class, probability, x, y, width, height), id) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
                 Some("probability") => probability ?= v.parse(),
@@ -103,23 +99,23 @@ impl TileData {
         let mut properties = HashMap::new();
         let mut objectgroup = None;
         let mut animation = None;
-        parse_tag!(parser, "tile", {
-            "image" => |attrs| {
-                image = Some(Image::new(parser, attrs, path_relative_to)?);
+        parse_tag!(elem, {
+            "image" => |elem| {
+                image = Some(Image::new(elem, path_relative_to)?);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
-            "objectgroup" => |attrs| {
+            "objectgroup" => |elem| {
                 // Tile objects are not allowed within tile object groups, so we can pass None as the
                 // tilesets vector
-                objectgroup = Some(ObjectLayerData::new(parser, attrs, None, None, path_relative_to, reader, cache)?.0);
+                objectgroup = Some(ObjectLayerData::new(elem, None, None, path_relative_to, reader, cache)?.0);
                 Ok(())
             },
-            "animation" => |_| {
-                animation = Some(parse_animation(parser)?);
+            "animation" => |elem| {
+                animation = Some(parse_animation(elem)?);
                 Ok(())
             },
         });

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashMap, path::Path};
 
 use crate::{
-    animation::{parse_animation, Frame},
+    ResourceCache, ResourceReader, Result, Tileset,
+    animation::{Frame, parse_animation},
     image::Image,
     layers::ObjectLayerData,
-    properties::{parse_properties, Properties},
+    properties::{Properties, parse_properties},
     util::{get_attrs, parse_tag},
-    ResourceCache, ResourceReader, Result, Tileset,
 };
 
 /// A tile ID, local to a tileset.

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -38,7 +38,7 @@ pub struct TileData {
     /// The animation frames of this tile.
     pub animation: Option<Vec<Frame>>,
     /// The type of this tile.
-    pub user_type: Option<String>,
+    pub user_type: String,
     /// The probability of this tile.
     pub probability: f32,
     /// The image rect of this tile, which is only used in image collection tilesets and corresponds
@@ -94,7 +94,7 @@ impl TileData {
             ((user_type, user_class, probability, x, y, width, height), id)
         );
 
-        let user_type = user_type.or(user_class);
+        let user_type = user_type.or(user_class).unwrap_or_default();
         let mut image = Option::None;
         let mut properties = HashMap::new();
         let mut objectgroup = None;

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -83,7 +83,7 @@ pub struct Tileset {
     pub properties: Properties,
 
     /// The custom tileset type, arbitrarily set by the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
 }
 
 /// The transformations that can be applied to the tiles of a tileset, for example when used by
@@ -296,7 +296,7 @@ struct TilesetProperties {
     tilecount: u32,
     columns: Option<u32>,
     name: String,
-    user_type: Option<String>,
+    user_type: String,
     tile_width: u32,
     tile_height: u32,
     tile_render_size: Option<TileRenderSize>,
@@ -379,7 +379,7 @@ impl Tileset {
                 spacing,
                 margin,
                 name: name.unwrap_or_default(),
-                user_type: user_type.or(user_class),
+                user_type: user_type.or(user_class).unwrap_or_default(),
                 root_path,
                 columns,
                 tilecount,
@@ -456,7 +456,7 @@ impl Tileset {
                 spacing,
                 margin,
                 name: name.unwrap_or_default(),
-                user_type: user_type.or(user_class),
+                user_type: user_type.or(user_class).unwrap_or_default(),
                 root_path,
                 columns,
                 tilecount,

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use crate::error::{Error, Result};
 use crate::image::Image;
@@ -51,6 +53,13 @@ pub struct Tileset {
     pub offset_x: i32,
     /// The y-offset to be used when drawing tiles of this tileset.
     pub offset_y: i32,
+    /// The size to use when rendering tiles of this tileset on a tile layer.
+    pub tile_render_size: TileRenderSize,
+    /// The fill mode to use when rendering tiles of this tileset, relevant when the tiles are
+    /// not rendered at their native size.
+    pub fill_mode: FillMode,
+    /// The alignment to use for tile objects referring to tiles of this tileset.
+    pub object_alignment: ObjectAlignment,
 
     /// A tileset can either:
     /// * have a single spritesheet `image` in `tileset` ("regular" tileset);
@@ -74,6 +83,184 @@ pub struct Tileset {
     pub user_type: Option<String>,
 }
 
+/// The size to use when rendering a tileset's tiles on a tile layer.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub enum TileRenderSize {
+    /// The tile is drawn at its own size, positioned so that its bottom left corner aligns with
+    /// the bottom left corner of its grid cell.
+    #[default]
+    Tile,
+    /// The tile is drawn at the size of the map's grid cell.
+    Grid,
+}
+
+#[derive(Debug)]
+/// An error arising from trying to parse a [`TileRenderSize`] that is not valid.
+pub struct TileRenderSizeParseError {
+    /// The invalid string found.
+    pub str_found: String,
+}
+
+impl fmt::Display for TileRenderSizeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "failed to parse tile render size, valid options are `tile` and `grid` \
+        but got `{}` instead",
+            self.str_found
+        ))
+    }
+}
+
+impl FromStr for TileRenderSize {
+    type Err = TileRenderSizeParseError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "tile" => Ok(TileRenderSize::Tile),
+            "grid" => Ok(TileRenderSize::Grid),
+            _ => Err(TileRenderSizeParseError {
+                str_found: s.to_owned(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for TileRenderSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TileRenderSize::Tile => write!(f, "tile"),
+            TileRenderSize::Grid => write!(f, "grid"),
+        }
+    }
+}
+
+/// The fill mode to use when rendering a tileset's tiles at a size differing from their native
+/// size.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub enum FillMode {
+    /// The tile image is stretched to fill the target rectangle.
+    #[default]
+    Stretch,
+    /// The tile image is scaled to fit the target rectangle while preserving its aspect ratio.
+    PreserveAspectFit,
+}
+
+#[derive(Debug)]
+/// An error arising from trying to parse a [`FillMode`] that is not valid.
+pub struct FillModeParseError {
+    /// The invalid string found.
+    pub str_found: String,
+}
+
+impl fmt::Display for FillModeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "failed to parse fill mode, valid options are `stretch` and `preserve-aspect-fit` \
+        but got `{}` instead",
+            self.str_found
+        ))
+    }
+}
+
+impl FromStr for FillMode {
+    type Err = FillModeParseError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "stretch" => Ok(FillMode::Stretch),
+            "preserve-aspect-fit" => Ok(FillMode::PreserveAspectFit),
+            _ => Err(FillModeParseError {
+                str_found: s.to_owned(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for FillMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FillMode::Stretch => write!(f, "stretch"),
+            FillMode::PreserveAspectFit => write!(f, "preserve-aspect-fit"),
+        }
+    }
+}
+
+/// The alignment to use for tile objects referring to a tileset's tiles.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+#[allow(missing_docs)]
+pub enum ObjectAlignment {
+    /// Tile objects use the alignment that older Tiled versions used: [`BottomLeft`] in
+    /// orthogonal maps and [`Bottom`] in isometric maps.
+    ///
+    /// [`BottomLeft`]: ObjectAlignment::BottomLeft
+    /// [`Bottom`]: ObjectAlignment::Bottom
+    #[default]
+    Unspecified,
+    TopLeft,
+    Top,
+    TopRight,
+    Left,
+    Center,
+    Right,
+    BottomLeft,
+    Bottom,
+    BottomRight,
+}
+
+#[derive(Debug)]
+/// An error arising from trying to parse an [`ObjectAlignment`] that is not valid.
+pub struct ObjectAlignmentParseError {
+    /// The invalid string found.
+    pub str_found: String,
+}
+
+impl fmt::Display for ObjectAlignmentParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "failed to parse object alignment, valid options are `unspecified`, `topleft`, \
+        `top`, `topright`, `left`, `center`, `right`, `bottomleft`, `bottom` and `bottomright` \
+        but got `{}` instead",
+            self.str_found
+        ))
+    }
+}
+
+impl FromStr for ObjectAlignment {
+    type Err = ObjectAlignmentParseError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "unspecified" => Ok(ObjectAlignment::Unspecified),
+            "topleft" => Ok(ObjectAlignment::TopLeft),
+            "top" => Ok(ObjectAlignment::Top),
+            "topright" => Ok(ObjectAlignment::TopRight),
+            "left" => Ok(ObjectAlignment::Left),
+            "center" => Ok(ObjectAlignment::Center),
+            "right" => Ok(ObjectAlignment::Right),
+            "bottomleft" => Ok(ObjectAlignment::BottomLeft),
+            "bottom" => Ok(ObjectAlignment::Bottom),
+            "bottomright" => Ok(ObjectAlignment::BottomRight),
+            _ => Err(ObjectAlignmentParseError {
+                str_found: s.to_owned(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for ObjectAlignment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ObjectAlignment::Unspecified => write!(f, "unspecified"),
+            ObjectAlignment::TopLeft => write!(f, "topleft"),
+            ObjectAlignment::Top => write!(f, "top"),
+            ObjectAlignment::TopRight => write!(f, "topright"),
+            ObjectAlignment::Left => write!(f, "left"),
+            ObjectAlignment::Center => write!(f, "center"),
+            ObjectAlignment::Right => write!(f, "right"),
+            ObjectAlignment::BottomLeft => write!(f, "bottomleft"),
+            ObjectAlignment::Bottom => write!(f, "bottom"),
+            ObjectAlignment::BottomRight => write!(f, "bottomright"),
+        }
+    }
+}
+
 pub(crate) enum EmbeddedParseResultType {
     ExternalReference { tileset_path: PathBuf },
     Embedded { tileset: Tileset },
@@ -94,6 +281,9 @@ struct TilesetProperties {
     user_type: Option<String>,
     tile_width: u32,
     tile_height: u32,
+    tile_render_size: Option<TileRenderSize>,
+    fill_mode: Option<FillMode>,
+    object_alignment: Option<ObjectAlignment>,
     /// The root all non-absolute paths contained within the tileset are relative to.
     root_path: PathBuf,
 }
@@ -140,6 +330,7 @@ impl Tileset {
     ) -> Result<EmbeddedParseResult> {
         let (
             (spacing, margin, columns, name, user_type, user_class),
+            (tile_render_size, fill_mode, object_alignment),
             (tilecount, first_gid, tile_width, tile_height),
         ) = get_attrs!(
            for v in (attrs) {
@@ -149,13 +340,16 @@ impl Tileset {
             Some("name") => name = v.to_string(),
             Some("type") => user_type ?= v.parse(),
             Some("class") => user_class ?= v.parse(),
+            Some("tilerendersize") => tile_render_size ?= v.parse::<TileRenderSize>(),
+            Some("fillmode") => fill_mode ?= v.parse::<FillMode>(),
+            Some("objectalignment") => object_alignment ?= v.parse::<ObjectAlignment>(),
 
             "tilecount" => tilecount ?= v.parse::<u32>(),
             "firstgid" => first_gid ?= v.parse::<u32>().map(Gid),
             "tilewidth" => tile_width ?= v.parse::<u32>(),
             "tileheight" => tile_height ?= v.parse::<u32>(),
            }
-           ((spacing, margin, columns, name, user_type, user_class), (tilecount, first_gid, tile_width, tile_height))
+           ((spacing, margin, columns, name, user_type, user_class), (tile_render_size, fill_mode, object_alignment), (tilecount, first_gid, tile_width, tile_height))
         );
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
@@ -173,6 +367,9 @@ impl Tileset {
                 tilecount,
                 tile_height,
                 tile_width,
+                tile_render_size,
+                fill_mode,
+                object_alignment,
             },
             reader,
             cache,
@@ -211,6 +408,7 @@ impl Tileset {
     ) -> Result<Tileset> {
         let (
             (spacing, margin, columns, name, user_type, user_class),
+            (tile_render_size, fill_mode, object_alignment),
             (tilecount, tile_width, tile_height),
         ) = get_attrs!(
             for v in (elem.attrs) {
@@ -220,12 +418,15 @@ impl Tileset {
                 Some("name") => name = v.to_string(),
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
+                Some("tilerendersize") => tile_render_size ?= v.parse::<TileRenderSize>(),
+                Some("fillmode") => fill_mode ?= v.parse::<FillMode>(),
+                Some("objectalignment") => object_alignment ?= v.parse::<ObjectAlignment>(),
 
                 "tilecount" => tilecount ?= v.parse::<u32>(),
                 "tilewidth" => tile_width ?= v.parse::<u32>(),
                 "tileheight" => tile_height ?= v.parse::<u32>(),
             }
-            ((spacing, margin, columns, name, user_type, user_class), (tilecount, tile_width, tile_height))
+            ((spacing, margin, columns, name, user_type, user_class), (tile_render_size, fill_mode, object_alignment), (tilecount, tile_width, tile_height))
         );
 
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
@@ -243,6 +444,9 @@ impl Tileset {
                 tilecount,
                 tile_height,
                 tile_width,
+                tile_render_size,
+                fill_mode,
+                object_alignment,
             },
             reader,
             cache,
@@ -325,6 +529,9 @@ impl Tileset {
             columns,
             offset_x: offset.0,
             offset_y: offset.1,
+            tile_render_size: prop.tile_render_size.unwrap_or_default(),
+            fill_mode: prop.fill_mode.unwrap_or_default(),
+            object_alignment: prop.object_alignment.unwrap_or_default(),
             tilecount: prop.tilecount,
             image,
             tiles,

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -5,11 +5,11 @@ use std::str::FromStr;
 
 use crate::error::{Error, Result};
 use crate::image::Image;
-use crate::properties::{parse_properties, Properties};
+use crate::properties::{Properties, parse_properties};
 use crate::tile::TileData;
 use crate::{
-    util::{get_attrs, parse_tag},
     Gid, InvalidTilesetError, ResourceCache, ResourceReader, Tile, TileId,
+    util::{get_attrs, parse_tag},
 };
 
 mod wangset;
@@ -281,7 +281,7 @@ impl fmt::Display for ObjectAlignment {
 
 pub(crate) enum EmbeddedParseResultType {
     ExternalReference { tileset_path: PathBuf },
-    Embedded { tileset: Tileset },
+    Embedded { tileset: Box<Tileset> },
 }
 
 pub(crate) struct EmbeddedParseResult {
@@ -309,13 +309,13 @@ struct TilesetProperties {
 impl Tileset {
     /// Gets the tile with the specified ID from the tileset.
     #[inline]
-    pub fn get_tile(&self, id: TileId) -> Option<Tile> {
+    pub fn get_tile(&self, id: TileId) -> Option<Tile<'_>> {
         self.tiles.get(&id).map(|data| Tile::new(self, data))
     }
 
     /// Iterates through the tiles from this tileset.
     #[inline]
-    pub fn tiles(&self) -> impl ExactSizeIterator<Item = (TileId, Tile)> {
+    pub fn tiles(&self) -> impl ExactSizeIterator<Item = (TileId, Tile<'_>)> {
         self.tiles
             .iter()
             .map(move |(id, data)| (*id, Tile::new(self, data)))
@@ -394,7 +394,9 @@ impl Tileset {
         )
         .map(|tileset| EmbeddedParseResult {
             first_gid,
-            result_type: EmbeddedParseResultType::Embedded { tileset },
+            result_type: EmbeddedParseResultType::Embedded {
+                tileset: Box::new(tileset),
+            },
         })
     }
 

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -60,6 +60,9 @@ pub struct Tileset {
     pub fill_mode: FillMode,
     /// The alignment to use for tile objects referring to tiles of this tileset.
     pub object_alignment: ObjectAlignment,
+    /// The transformations that can be applied to the tiles of this tileset, for example when
+    /// used by Wang sets.
+    pub transformations: Transformations,
 
     /// A tileset can either:
     /// * have a single spritesheet `image` in `tileset` ("regular" tileset);
@@ -81,6 +84,21 @@ pub struct Tileset {
 
     /// The custom tileset type, arbitrarily set by the user.
     pub user_type: Option<String>,
+}
+
+/// The transformations that can be applied to the tiles of a tileset, for example when used by
+/// Wang sets.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub struct Transformations {
+    /// Whether the tiles in this tileset can be flipped horizontally.
+    pub hflip: bool,
+    /// Whether the tiles in this tileset can be flipped vertically.
+    pub vflip: bool,
+    /// Whether the tiles in this tileset can be rotated in 90-degree increments.
+    pub rotate: bool,
+    /// Whether untransformed tiles remain preferred, otherwise transformed tiles are used to
+    /// produce more variations.
+    pub prefer_untransformed: bool,
 }
 
 /// The size to use when rendering a tileset's tiles on a tile layer.
@@ -465,6 +483,7 @@ impl Tileset {
         let mut properties = HashMap::new();
         let mut wang_sets = Vec::new();
         let mut offset = (0i32, 0i32);
+        let mut transformations = Transformations::default();
 
         parse_tag!(elem, {
             "image" => |elem| {
@@ -473,6 +492,10 @@ impl Tileset {
             },
             "tileoffset" => |elem| {
                 offset = parse_tileoffset(elem)?;
+                Ok(())
+            },
+            "transformations" => |elem| {
+                transformations = parse_transformations(elem)?;
                 Ok(())
             },
             "properties" => |elem| {
@@ -532,6 +555,7 @@ impl Tileset {
             tile_render_size: prop.tile_render_size.unwrap_or_default(),
             fill_mode: prop.fill_mode.unwrap_or_default(),
             object_alignment: prop.object_alignment.unwrap_or_default(),
+            transformations,
             tilecount: prop.tilecount,
             image,
             tiles,
@@ -555,6 +579,28 @@ impl Tileset {
                 )
             })
     }
+}
+
+/// Parse the optional <transformations hflip=... vflip=... rotate=... preferuntransformed=.../> tag.
+fn parse_transformations<R: std::io::BufRead>(
+    elem: crate::util::XmlElement<'_, R>,
+) -> Result<Transformations> {
+    let (hflip, vflip, rotate, prefer_untransformed) = get_attrs!(
+        for v in (elem.attrs) {
+            Some("hflip") => hflip = v == "1",
+            Some("vflip") => vflip = v == "1",
+            Some("rotate") => rotate = v == "1",
+            Some("preferuntransformed") => prefer_untransformed = v == "1",
+        }
+        (hflip, vflip, rotate, prefer_untransformed)
+    );
+    parse_tag!(elem, {});
+    Ok(Transformations {
+        hflip: hflip.unwrap_or(false),
+        vflip: vflip.unwrap_or(false),
+        rotate: rotate.unwrap_or(false),
+        prefer_untransformed: prefer_untransformed.unwrap_or(false),
+    })
 }
 
 /// Parse the optional <tileoffset x=... y=.../> tag.

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use xml::attribute::OwnedAttribute;
-
 use crate::error::{Error, Result};
 use crate::image::Image;
 use crate::properties::{parse_properties, Properties};
 use crate::tile::TileData;
-use crate::{util::*, Gid, InvalidTilesetError, ResourceCache, ResourceReader, Tile, TileId};
+use crate::{
+    util::{get_attrs, parse_tag},
+    Gid, InvalidTilesetError, ResourceCache, ResourceReader, Tile, TileId,
+};
 
 mod wangset;
 pub use wangset::*;
@@ -114,14 +115,14 @@ impl Tileset {
 }
 
 impl Tileset {
-    pub(crate) fn parse_xml_in_map(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: &[OwnedAttribute],
+    pub(crate) fn parse_xml_in_map<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         path: &Path, // Template or Map file
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
     ) -> Result<EmbeddedParseResult> {
-        Tileset::parse_xml_embedded(parser, attrs, path, reader, cache).or_else(|err| {
+        let attrs = elem.attrs.clone();
+        Tileset::parse_xml_embedded(elem, attrs.clone(), path, reader, cache).or_else(|err| {
             if matches!(err, Error::MalformedAttributes(_)) {
                 Tileset::parse_xml_reference(attrs, path)
             } else {
@@ -130,9 +131,9 @@ impl Tileset {
         })
     }
 
-    fn parse_xml_embedded(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: &[OwnedAttribute],
+    fn parse_xml_embedded<'a, R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'a, R>,
+        attrs: quick_xml::events::BytesStart<'a>,
         path: &Path, // Template or Map file
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -141,11 +142,11 @@ impl Tileset {
             (spacing, margin, columns, name, user_type, user_class),
             (tilecount, first_gid, tile_width, tile_height),
         ) = get_attrs!(
-           for v in attrs {
+           for v in (attrs) {
             Some("spacing") => spacing ?= v.parse(),
             Some("margin") => margin ?= v.parse(),
             Some("columns") => columns ?= v.parse(),
-            Some("name") => name = v,
+            Some("name") => name = v.to_string(),
             Some("type") => user_type ?= v.parse(),
             Some("class") => user_class ?= v.parse(),
 
@@ -160,7 +161,7 @@ impl Tileset {
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
 
         Self::finish_parsing_xml(
-            parser,
+            elem,
             path.to_owned(),
             TilesetProperties {
                 spacing,
@@ -182,14 +183,14 @@ impl Tileset {
         })
     }
 
-    fn parse_xml_reference(
-        attrs: &[OwnedAttribute],
+    fn parse_xml_reference<'a>(
+        attrs: quick_xml::events::BytesStart<'a>,
         map_path: &Path,
     ) -> Result<EmbeddedParseResult> {
         let (first_gid, source) = get_attrs!(
-            for v in attrs {
+            for v in (attrs) {
                 "firstgid" => first_gid ?= v.parse::<u32>().map(Gid),
-                "source" => source = v,
+                "source" => source = v.to_string(),
             }
             (first_gid, source)
         );
@@ -202,9 +203,8 @@ impl Tileset {
         })
     }
 
-    pub(crate) fn parse_external_tileset(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: &[OwnedAttribute],
+    pub(crate) fn parse_external_tileset<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         path: &Path,
         reader: &mut impl ResourceReader,
         cache: &mut impl ResourceCache,
@@ -213,11 +213,11 @@ impl Tileset {
             (spacing, margin, columns, name, user_type, user_class),
             (tilecount, tile_width, tile_height),
         ) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 Some("spacing") => spacing ?= v.parse(),
                 Some("margin") => margin ?= v.parse(),
                 Some("columns") => columns ?= v.parse(),
-                Some("name") => name = v,
+                Some("name") => name = v.to_string(),
                 Some("type") => user_type ?= v.parse(),
                 Some("class") => user_class ?= v.parse(),
 
@@ -231,7 +231,7 @@ impl Tileset {
         let root_path = path.parent().ok_or(Error::PathIsNotFile)?.to_owned();
 
         Self::finish_parsing_xml(
-            parser,
+            elem,
             path.to_owned(),
             TilesetProperties {
                 spacing,
@@ -249,8 +249,8 @@ impl Tileset {
         )
     }
 
-    fn finish_parsing_xml(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
+    fn finish_parsing_xml<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
         container_path: PathBuf,
         prop: TilesetProperties,
         reader: &mut impl ResourceReader,
@@ -262,27 +262,32 @@ impl Tileset {
         let mut wang_sets = Vec::new();
         let mut offset = (0i32, 0i32);
 
-        parse_tag!(parser, "tileset", {
-            "image" => |attrs| {
-                image = Some(Image::new(parser, attrs, &prop.root_path)?);
+        parse_tag!(elem, {
+            "image" => |elem| {
+                image = Some(Image::new(elem, &prop.root_path)?);
                 Ok(())
             },
-            "tileoffset" => |attrs| {
-                offset = parse_tileoffset(attrs)?;
+            "tileoffset" => |elem| {
+                offset = parse_tileoffset(elem)?;
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
-            "tile" => |attrs| {
-                let (id, tile) = TileData::new(parser, attrs, &prop.root_path, reader, cache)?;
+            "tile" => |elem| {
+                let (id, tile) = TileData::new(elem, &prop.root_path, reader, cache)?;
                 tiles.insert(id, tile);
                 Ok(())
             },
-            "wangset" => |attrs| {
-                let set = WangSet::new(parser, attrs)?;
-                wang_sets.push(set);
+            "wangsets" => |elem: crate::util::XmlElement<'_, R>| {
+                parse_tag!(elem, {
+                    "wangset" => |elem| {
+                        let set = WangSet::new(elem)?;
+                        wang_sets.push(set);
+                        Ok(())
+                    },
+                });
                 Ok(())
             },
         });
@@ -346,12 +351,16 @@ impl Tileset {
 }
 
 /// Parse the optional <tileoffset x=... y=.../> tag.
-fn parse_tileoffset(attrs: Vec<OwnedAttribute>) -> Result<(i32, i32)> {
-    Ok(get_attrs!(
-        for v in attrs {
+fn parse_tileoffset<R: std::io::BufRead>(
+    elem: crate::util::XmlElement<'_, R>,
+) -> Result<(i32, i32)> {
+    let offset = get_attrs!(
+        for v in (elem.attrs) {
             "x" => offset_x ?= v.parse::<i32>(),
             "y" => offset_y ?= v.parse::<i32>(),
         }
         (offset_x, offset_y)
-    ))
+    );
+    parse_tag!(elem, {});
+    Ok(offset)
 }

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -31,6 +31,8 @@ impl Default for WangSetType {
 pub struct WangSet {
     /// The name of the Wang set.
     pub name: String,
+    /// The custom type of the Wang set, arbitrarily set by the user.
+    pub user_type: Option<String>,
     /// Type of Wang set.
     pub wang_set_type: WangSetType,
     /// The tile ID of the tile representing this Wang set.
@@ -49,13 +51,14 @@ impl WangSet {
         elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangSet> {
         // Get common data
-        let (name, wang_set_type, tile) = get_attrs!(
+        let ((user_type,), (name, wang_set_type, tile)) = get_attrs!(
             for v in (elem.attrs) {
+                Some("class") => user_type ?= v.parse::<String>(),
                 "name" => name ?= v.parse::<String>(),
                 "type" => wang_set_type ?= v.parse::<String>(),
                 "tile" => tile ?= v.parse::<i64>(),
             }
-            (name, wang_set_type, tile)
+            ((user_type,), (name, wang_set_type, tile))
         );
 
         let wang_set_type = match wang_set_type.as_str() {
@@ -88,6 +91,7 @@ impl WangSet {
 
         Ok(WangSet {
             name,
+            user_type,
             wang_set_type,
             tile,
             wang_colors,

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    properties::{parse_properties, Properties},
-    util::{get_attrs, parse_tag},
     Result, TileId,
+    properties::{Properties, parse_properties},
+    util::{get_attrs, parse_tag},
 };
 
 mod wang_color;
@@ -12,18 +12,13 @@ mod wang_tile;
 pub use wang_tile::*;
 
 /// Wang set's terrain brush connection type.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
 #[allow(missing_docs)]
 pub enum WangSetType {
     Corner,
     Edge,
+    #[default]
     Mixed,
-}
-
-impl Default for WangSetType {
-    fn default() -> Self {
-        WangSetType::Mixed
-    }
 }
 
 /// Raw data belonging to a WangSet.

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::Error,
     properties::{parse_properties, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
     Result, TileId,
 };
 
@@ -48,13 +45,12 @@ pub struct WangSet {
 
 impl WangSet {
     /// Reads data from XML parser to create a WangSet.
-    pub fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangSet> {
         // Get common data
         let (name, wang_set_type, tile) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "name" => name ?= v.parse::<String>(),
                 "type" => wang_set_type ?= v.parse::<String>(),
                 "tile" => tile ?= v.parse::<i64>(),
@@ -73,19 +69,19 @@ impl WangSet {
         let mut wang_colors = Vec::new();
         let mut wang_tiles = HashMap::new();
         let mut properties = HashMap::new();
-        parse_tag!(parser, "wangset", {
-            "wangcolor" => |attrs| {
-                let color = WangColor::new(parser, attrs)?;
+        parse_tag!(elem, {
+            "wangcolor" => |elem| {
+                let color = WangColor::new(elem)?;
                 wang_colors.push(color);
                 Ok(())
             },
-            "wangtile" => |attrs| {
-                let (id, t) = WangTile::new(parser, attrs)?;
+            "wangtile" => |elem| {
+                let (id, t) = WangTile::new(elem)?;
                 wang_tiles.insert(id, t);
                 Ok(())
             },
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/tileset/wangset.rs
+++ b/src/tileset/wangset.rs
@@ -32,7 +32,7 @@ pub struct WangSet {
     /// The name of the Wang set.
     pub name: String,
     /// The custom type of the Wang set, arbitrarily set by the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
     /// Type of Wang set.
     pub wang_set_type: WangSetType,
     /// The tile ID of the tile representing this Wang set.
@@ -91,7 +91,7 @@ impl WangSet {
 
         Ok(WangSet {
             name,
-            user_type,
+            user_type: user_type.unwrap_or_default(),
             wang_set_type,
             tile,
             wang_colors,

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    properties::{parse_properties, Color, Properties},
-    util::{get_attrs, parse_tag},
     Result, TileId,
+    properties::{Color, Properties, parse_properties},
+    util::{get_attrs, parse_tag},
 };
 
 /// Stores the data of the Wang color.

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -12,7 +12,7 @@ pub struct WangColor {
     /// The name of this color.
     pub name: String,
     /// The custom type of this color, arbitrarily set by the user.
-    pub user_type: Option<String>,
+    pub user_type: String,
     #[allow(missing_docs)]
     pub color: Color,
     /// The tile ID of the tile representing this color.
@@ -53,7 +53,7 @@ impl WangColor {
 
         Ok(WangColor {
             name,
-            user_type,
+            user_type: user_type.unwrap_or_default(),
             color,
             tile,
             probability,

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
-    error::Error,
     properties::{parse_properties, Color, Properties},
-    util::{get_attrs, parse_tag, XmlEventResult},
+    util::{get_attrs, parse_tag},
     Result, TileId,
 };
 
@@ -26,13 +23,12 @@ pub struct WangColor {
 
 impl WangColor {
     /// Reads data from XML parser to create a WangColor.
-    pub fn new(
-        parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangColor> {
         // Get common data
         let (name, color, tile, probability) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "name" => name ?= v.parse::<String>(),
                 "color" => color ?= v.parse(),
                 "tile" => tile ?= v.parse::<i64>(),
@@ -45,9 +41,9 @@ impl WangColor {
 
         // Gather variable data
         let mut properties = HashMap::new();
-        parse_tag!(parser, "wangcolor", {
-            "properties" => |_| {
-                properties = parse_properties(parser)?;
+        parse_tag!(elem, {
+            "properties" => |elem| {
+                properties = parse_properties(elem)?;
                 Ok(())
             },
         });

--- a/src/tileset/wangset/wang_color.rs
+++ b/src/tileset/wangset/wang_color.rs
@@ -11,6 +11,8 @@ use crate::{
 pub struct WangColor {
     /// The name of this color.
     pub name: String,
+    /// The custom type of this color, arbitrarily set by the user.
+    pub user_type: Option<String>,
     #[allow(missing_docs)]
     pub color: Color,
     /// The tile ID of the tile representing this color.
@@ -27,14 +29,15 @@ impl WangColor {
         elem: crate::util::XmlElement<'_, R>,
     ) -> Result<WangColor> {
         // Get common data
-        let (name, color, tile, probability) = get_attrs!(
+        let ((user_type,), (name, color, tile, probability)) = get_attrs!(
             for v in (elem.attrs) {
+                Some("class") => user_type ?= v.parse::<String>(),
                 "name" => name ?= v.parse::<String>(),
                 "color" => color ?= v.parse(),
                 "tile" => tile ?= v.parse::<i64>(),
                 "probability" => probability ?= v.parse::<f32>(),
             }
-            (name, color, tile, probability)
+            ((user_type,), (name, color, tile, probability))
         );
 
         let tile = if tile >= 0 { Some(tile as u32) } else { None };
@@ -50,6 +53,7 @@ impl WangColor {
 
         Ok(WangColor {
             name,
+            user_type,
             color,
             tile,
             probability,

--- a/src/tileset/wangset/wang_tile.rs
+++ b/src/tileset/wangset/wang_tile.rs
@@ -1,10 +1,8 @@
 use std::str::FromStr;
 
-use xml::attribute::OwnedAttribute;
-
 use crate::{
     error::Error,
-    util::{get_attrs, XmlEventResult},
+    util::{get_attrs, parse_tag},
     Result, TileId,
 };
 
@@ -44,19 +42,19 @@ pub struct WangTile {
 
 impl WangTile {
     /// Reads data from XML parser to create a WangTile.
-    pub(crate) fn new(
-        _parser: &mut impl Iterator<Item = XmlEventResult>,
-        attrs: Vec<OwnedAttribute>,
+    pub(crate) fn new<R: std::io::BufRead>(
+        elem: crate::util::XmlElement<'_, R>,
     ) -> Result<(TileId, WangTile)> {
         // Get common data
         let (tile_id, wang_id) = get_attrs!(
-            for v in attrs {
+            for v in (elem.attrs) {
                 "tileid" => tile_id ?= v.parse::<u32>(),
                 "wangid" => wang_id ?= v.parse(),
             }
             (tile_id, wang_id)
         );
 
+        parse_tag!(elem, {});
         Ok((tile_id, WangTile { wang_id }))
     }
 }

--- a/src/tileset/wangset/wang_tile.rs
+++ b/src/tileset/wangset/wang_tile.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
 
 use crate::{
+    Result, TileId,
     error::Error,
     util::{get_attrs, parse_tag},
-    Result, TileId,
 };
 
 /// The Wang ID, stored as an array of 8 u8 values.

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,14 +4,15 @@
 /// The syntax is:
 /// ```ignore
 /// get_attrs!(
-///     for $attr in $attributes {
+///     for $attr in ($attributes) {
 ///         $($branch),*
 ///     }
 ///     $expression_to_return
 /// )
 /// ```
-/// Where `$attributes` is anything that implements `Iterator<Item = OwnedAttribute>`,
-/// and `$attr` is the value of the attribute (a String) going to be used in each branch.
+/// Where `$attributes` is anything that exposes `attributes()` for XML element attributes,
+/// and `$attr` is the value of the attribute (a &str) going to be used in each branch. The
+/// `$attributes` expression must be parenthesized to satisfy macro parsing.
 ///
 /// Each branch indicates a variable to be set once a certain attribute is found.
 /// Its syntax is as follows:
@@ -21,16 +22,16 @@
 ///
 /// For instance:
 /// ```ignore
-/// "source" => source = v,
+/// "source" => source = v.to_string(),
 /// ```
-/// The variable set has an inferred type `T`. In this case, `source` is inferred to be a `String`,
-/// and `$attr` has been named `v`.
+/// The variable set has an inferred type `T`. In this case, `source` is inferred to be a `String`
+/// because we call `to_string()`, and `$attr` has been named `v`.
 ///
 /// If `Some` encapsulates the attribute name (like so: `Some("attribute name")`) then the attribute
 /// is meant to be optional, which will make the variable an `Option<T>` rather than `T`. Even if it
 /// is technically an Option, the assignment is still done *as if it was `T`*, for instance:
 /// ```ignore
-/// Some("name") => name = v,
+/// Some("name") => name = v.to_string(),
 /// ```
 ///
 /// Finally, branches can also use `?=` instead of `=`, which will make them accept a `Result<T, E>`
@@ -42,7 +43,7 @@
 /// Some("spacing") => spacing ?= v.parse(),
 /// Some("margin") => margin ?= v.parse(),
 /// Some("columns") => columns ?= v.parse(),
-/// Some("name") => name = v,
+/// Some("name") => name = v.to_string(),
 ///
 /// "tilecount" => tilecount ?= v.parse::<u32>(),
 /// "tilewidth" => tile_width ?= v.parse::<u32>(),
@@ -55,10 +56,10 @@
 /// ## Example
 /// ```ignore
 /// let ((c, infinite), (v, o, w, h, tw, th)) = get_attrs!(
-///     for v in attrs {
+///     for v in (attrs) {
 ///         Some("backgroundcolor") => colour ?= v.parse(),
 ///         Some("infinite") => infinite = v == "1",
-///         "version" => version = v,
+///         "version" => version = v.to_string(),
 ///         "orientation" => orientation ?= v.parse::<Orientation>(),
 ///         "width" => width ?= v.parse::<u32>(),
 ///         "height" => height ?= v.parse::<u32>(),
@@ -70,7 +71,7 @@
 /// ```
 macro_rules! get_attrs {
     (
-        for $attr:ident in $attrs:ident {
+        for $attr:ident in ($attrs:expr) {
             $($branches:tt)*
         }
         $ret_expr:expr
@@ -78,9 +79,16 @@ macro_rules! get_attrs {
         {
             $crate::util::let_attr_branches!($($branches)*);
 
-            for attr in $attrs.iter() {
-                let $attr = attr.value.clone();
-                $crate::util::process_attr_branches!(attr; $($branches)*);
+            for attr in ($attrs).attributes() {
+                let attr =
+                    attr.map_err(|err| $crate::Error::XmlDecodingError(err.into()))?;
+                let local_name = attr.key.local_name();
+                let __attr_name = local_name.as_ref();
+                let __attr_value = attr
+                    .unescape_value()
+                    .map_err($crate::Error::XmlDecodingError)?;
+                let $attr = __attr_value.as_ref();
+                $crate::util::process_attr_branches!(__attr_name; $attr; $($branches)*);
             }
 
             $crate::util::handle_attr_branches!($($branches)*);
@@ -107,19 +115,19 @@ macro_rules! let_attr_branches {
 pub(crate) use let_attr_branches;
 
 macro_rules! process_attr_branches {
-    ($attr:ident; ) => {};
+    ($name:ident; $value:ident; ) => {};
 
-    ($attr:ident; Some($attr_pat_opt:literal) => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if(&$attr.name.local_name == $attr_pat_opt) {
+    ($name:ident; $value:ident; Some($attr_pat_opt:literal) => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
+        if $name == $attr_pat_opt.as_bytes() {
             $opt_var = Some($opt_expr);
         }
         else {
-            $crate::util::process_attr_branches!($attr; $($($tail)*)?);
+            $crate::util::process_attr_branches!($name; $value; $($($tail)*)?);
         }
     };
 
-    ($attr:ident; Some($attr_pat_opt:literal) => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if(&$attr.name.local_name == $attr_pat_opt) {
+    ($name:ident; $value:ident; Some($attr_pat_opt:literal) => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
+        if $name == $attr_pat_opt.as_bytes() {
             $opt_var = Some($opt_expr.map_err(|_|
                 $crate::Error::MalformedAttributes(
                     concat!("Error parsing optional attribute '", $attr_pat_opt, "'").to_owned()
@@ -127,21 +135,21 @@ macro_rules! process_attr_branches {
             )?);
         }
         else {
-            $crate::util::process_attr_branches!($attr; $($($tail)*)?);
+            $crate::util::process_attr_branches!($name; $value; $($($tail)*)?);
         }
     };
 
-    ($attr:ident; $attr_pat_opt:literal => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if(&$attr.name.local_name == $attr_pat_opt) {
+    ($name:ident; $value:ident; $attr_pat_opt:literal => $opt_var:ident = $opt_expr:expr $(, $($tail:tt)*)?) => {
+        if $name == $attr_pat_opt.as_bytes() {
             $opt_var = Some($opt_expr);
         }
         else {
-            $crate::util::process_attr_branches!($attr; $($($tail)*)?);
+            $crate::util::process_attr_branches!($name; $value; $($($tail)*)?);
         }
     };
 
-    ($attr:ident; $attr_pat_opt:literal => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
-        if(&$attr.name.local_name == $attr_pat_opt) {
+    ($name:ident; $value:ident; $attr_pat_opt:literal => $opt_var:ident ?= $opt_expr:expr $(, $($tail:tt)*)?) => {
+        if $name == $attr_pat_opt.as_bytes() {
             $opt_var = Some($opt_expr.map_err(|_|
                 $crate::Error::MalformedAttributes(
                     concat!("Error parsing attribute '", $attr_pat_opt, "'").to_owned()
@@ -149,7 +157,7 @@ macro_rules! process_attr_branches {
             )?);
         }
         else {
-            $crate::util::process_attr_branches!($attr; $($($tail)*)?);
+            $crate::util::process_attr_branches!($name; $value; $($($tail)*)?);
         }
     }
 }
@@ -166,7 +174,7 @@ macro_rules! handle_attr_branches {
     ($attr_pat_opt:literal => $opt_var:ident $(?)?= $opt_expr:expr $(, $($tail:tt)*)?) => {
         let $opt_var = $opt_var
             .ok_or_else(||
-                Error::MalformedAttributes(
+                $crate::Error::MalformedAttributes(
                     concat!("Missing attribute: ", $attr_pat_opt).to_owned()
                 )
             )?;
@@ -180,27 +188,52 @@ pub(crate) use handle_attr_branches;
 /// Goes through the children of the tag and will call the correct function for
 /// that child. Closes the tag.
 macro_rules! parse_tag {
-    ($parser:expr, $close_tag:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {
-        while let Some(next) = $parser.next() {
-            match next.map_err(Error::XmlDecodingError)? {
-                #[allow(unused_variables)]
-                $(
-                    xml::reader::XmlEvent::StartElement {name, attributes, ..}
-                        if name.local_name == $open_tag => $open_method(attributes)?,
-                )*
+    ($elem:expr, {$($open_tag:expr => $open_method:expr),* $(,)*}) => {{
+        let __elem = $elem;
+        if !__elem.is_empty {
+            let __reader = __elem.into_reader();
+            let mut __event_buf = Vec::new();
+            loop {
+                let e = match __reader
+                    .read_event_into(&mut __event_buf)
+                    .map_err($crate::Error::XmlDecodingError)?
+                {
+                    quick_xml::events::Event::Start(e) => Some((e, false)),
+                    quick_xml::events::Event::Empty(e) => Some((e, true)),
+                    quick_xml::events::Event::End(_) => {
+                        break;
+                    }
+                    quick_xml::events::Event::Eof => {
+                        return Err($crate::Error::PrematureEnd(
+                            "Document ended before we expected.".to_string(),
+                        ));
+                    }
+                    _ => None,
+                };
 
-
-                xml::reader::XmlEvent::EndElement {name, ..} => if name.local_name == $close_tag {
-                    break;
+                if let Some((e, is_empty)) = e {
+                    match e.local_name().as_ref() {
+                        $(
+                            name if name == $open_tag.as_bytes() => {
+                                let mut __child =
+                                    $crate::util::XmlElement::new(&mut *__reader, e, is_empty);
+                                $open_method(__child)?;
+                            }
+                        )*
+                        _ => {
+                            if !is_empty {
+                                let end = e.to_end().into_owned();
+                                drop(e);
+                                __reader
+                                    .read_to_end_into(end.name(), &mut __event_buf)
+                                    .map_err($crate::Error::XmlDecodingError)?;
+                            }
+                        }
+                    }
                 }
-
-                xml::reader::XmlEvent::EndDocument => {
-                    return Err(Error::PrematureEnd("Document ended before we expected.".to_string()));
-                }
-                _ => {}
             }
         }
-    }
+    }};
 }
 
 /// Creates a new type that wraps an internal data type over along with a map.
@@ -243,8 +276,6 @@ pub(crate) use parse_tag;
 
 use crate::{Gid, MapTilesetGid};
 
-pub(crate) type XmlEventResult = xml::reader::Result<xml::reader::XmlEvent>;
-
 /// Returns both the tileset and its index
 pub(crate) fn get_tileset_for_gid(
     tilesets: &[MapTilesetGid],
@@ -265,5 +296,123 @@ pub fn floor_div(a: i32, b: i32) -> i32 {
         d
     } else {
         d - ((a < 0) ^ (b < 0)) as i32
+    }
+}
+use std::io::BufRead;
+
+use quick_xml::{events::BytesStart, events::Event, Reader};
+
+use crate::{Error, Result};
+
+pub(crate) struct XmlElement<'a, R: BufRead> {
+    reader: &'a mut Reader<R>,
+    pub attrs: BytesStart<'a>,
+    pub is_empty: bool,
+}
+
+impl<'a, R: BufRead> XmlElement<'a, R> {
+    pub(crate) fn new(reader: &'a mut Reader<R>, attrs: BytesStart<'a>, is_empty: bool) -> Self {
+        Self {
+            reader,
+            attrs,
+            is_empty,
+        }
+    }
+
+    pub(crate) fn into_reader(self) -> &'a mut Reader<R> {
+        self.reader
+    }
+}
+
+pub(crate) fn read_text_or_cdata<R: BufRead, F, T>(
+    elem: XmlElement<'_, R>,
+    mut handler: F,
+) -> Result<T>
+where
+    F: for<'a> FnMut(&'a str) -> Result<T>,
+{
+    if elem.is_empty {
+        return handler("");
+    }
+
+    let reader = elem.into_reader();
+    let mut event_buf = Vec::new();
+    let mut result = None;
+    loop {
+        match reader
+            .read_event_into(&mut event_buf)
+            .map_err(Error::XmlDecodingError)?
+        {
+            Event::Text(e) if result.is_none() => {
+                let unescaped = e.unescape().map_err(Error::XmlDecodingError)?;
+                result = Some(Ok(handler(unescaped.as_ref())?));
+            }
+            Event::CData(e) if result.is_none() => {
+                let unescaped = String::from_utf8_lossy(e.as_ref());
+                result = Some(Ok(handler(unescaped.as_ref())?));
+            }
+            Event::Start(e) => {
+                let end = e.to_end().into_owned();
+                drop(e);
+                reader
+                    .read_to_end_into(end.name(), &mut event_buf)
+                    .map_err(Error::XmlDecodingError)?;
+            }
+            Event::Empty(_) => {}
+            Event::End(_) => return result.unwrap_or_else(|| handler("")),
+            Event::Eof => {
+                return Err(Error::PrematureEnd(
+                    "end of file while reading element contents".to_owned(),
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(crate) fn parse_root_element<R, F, T>(
+    reader: &mut Reader<R>,
+    tag: &[u8],
+    mut handler: F,
+) -> Result<T>
+where
+    R: BufRead,
+    F: FnMut(XmlElement<'_, R>) -> Result<T>,
+{
+    let mut event_buf = Vec::new();
+    loop {
+        let e = match reader
+            .read_event_into(&mut event_buf)
+            .map_err(Error::XmlDecodingError)?
+        {
+            Event::Start(e) => Some((e, false)),
+            Event::Empty(e) => Some((e, true)),
+            Event::End(e) => {
+                return Err(Error::MalformedAttributes(format!(
+                    "Unexpected closing tag </{}> before root element <{}>",
+                    String::from_utf8_lossy(e.local_name().as_ref()),
+                    String::from_utf8_lossy(tag),
+                )));
+            }
+            Event::Eof => {
+                return Err(Error::PrematureEnd(format!(
+                    "Document ended before root element <{}> was found",
+                    String::from_utf8_lossy(tag),
+                )));
+            }
+            _ => None,
+        };
+
+        if let Some((e, empty)) = e {
+            if e.local_name().as_ref() == tag {
+                return handler(XmlElement::new(reader, e, empty));
+            } else {
+                return Err(Error::MalformedAttributes(format!(
+                    "Expected root element <{}>, got <{}>",
+                    String::from_utf8_lossy(tag),
+                    String::from_utf8_lossy(e.local_name().as_ref()),
+                )));
+            }
+        }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -300,7 +300,7 @@ pub fn floor_div(a: i32, b: i32) -> i32 {
 }
 use std::io::BufRead;
 
-use quick_xml::{events::BytesStart, events::Event, Reader};
+use quick_xml::{Reader, events::BytesStart, events::Event};
 
 use crate::{Error, Result};
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -46,10 +46,7 @@ impl World {
     /// Utility function to test a vec of filenames against all defined patterns.
     /// Returns a vec of results with the parsed [`WorldMap`]s if it matches the pattern.
     pub fn match_paths<P: AsRef<Path>>(&self, paths: &[P]) -> Vec<Result<WorldMap, Error>> {
-        paths
-            .into_iter()
-            .map(|path| self.match_path(path))
-            .collect()
+        paths.iter().map(|path| self.match_path(path)).collect()
     }
 }
 
@@ -112,7 +109,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 
@@ -121,7 +118,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 
@@ -130,7 +127,7 @@ impl WorldPattern {
             None => {
                 return Err(Error::NoMatchFound {
                     path: path.to_owned(),
-                })
+                });
             }
         };
 
@@ -170,7 +167,7 @@ pub(crate) fn parse_world(
     reader: &mut impl ResourceReader,
 ) -> Result<World, Error> {
     let mut path = reader
-        .read_from(&world_path)
+        .read_from(world_path)
         .map_err(|err| Error::ResourceLoadingError {
             path: world_path.to_owned(),
             err: Box::new(err),
@@ -183,8 +180,7 @@ pub(crate) fn parse_world(
             err: Box::new(err),
         })?;
 
-    let mut world: World =
-        serde_json::from_str(&world_string).map_err(|err| Error::JsonDecodingError(err))?;
+    let mut world: World = serde_json::from_str(&world_string).map_err(Error::JsonDecodingError)?;
 
     world.source = world_path.to_owned();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use tiled::{
-    Color, FiniteTileLayer, HorizontalAlignment, LayerType, Loader, Map, ObjectShape,
+    Color, FiniteTileLayer, HorizontalAlignment, LayerType, Loader, Map, ObjectShape, Properties,
     PropertyValue, ResourceCache, TileLayer, TilesetLocation, VerticalAlignment, WangId,
 };
 
@@ -458,6 +458,100 @@ fn test_object_property() {
         0
     };
     assert_eq!(3, prop_value);
+}
+
+#[test]
+fn test_object_list_property() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_object_list_property.tmx")
+        .unwrap();
+    let layer = r.get_layer(1).unwrap();
+    let prop_value = if let Some(PropertyValue::ListValue(v)) = layer
+        .as_object_layer()
+        .unwrap()
+        .get_object(0)
+        .unwrap()
+        .properties
+        .get("list property")
+    {
+        v.clone()
+    } else {
+        vec![]
+    };
+    assert_eq!(
+        vec![
+            PropertyValue::ObjectValue(4),
+            PropertyValue::ObjectValue(3),
+            PropertyValue::BoolValue(true),
+        ],
+        prop_value
+    );
+}
+
+#[test]
+fn test_object_nested_list_property() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_object_nested_list_property.tmx")
+        .unwrap();
+    let layer = r.get_layer(1).unwrap();
+    let objects = layer.as_object_layer().unwrap();
+    let prop_value = if let Some(PropertyValue::ListValue(v)) = objects
+        .get_object(0)
+        .unwrap()
+        .properties
+        .get("list property")
+    {
+        v.clone()
+    } else {
+        vec![]
+    };
+    assert_eq!(
+        vec![
+            PropertyValue::ObjectValue(4),
+            PropertyValue::ObjectValue(3),
+            PropertyValue::BoolValue(true),
+            PropertyValue::ListValue(vec![
+                PropertyValue::BoolValue(false),
+                PropertyValue::BoolValue(true),
+                PropertyValue::ListValue(vec![
+                    PropertyValue::BoolValue(false),
+                    PropertyValue::BoolValue(true),
+                ])
+            ]),
+            PropertyValue::ListValue(vec![PropertyValue::ClassValue {
+                property_type: "ListClass".to_string(),
+                properties: Properties::from([(
+                    "list".to_string(),
+                    PropertyValue::ListValue(vec![PropertyValue::ClassValue {
+                        property_type: "Class".to_string(),
+                        properties: Properties::from([
+                            (
+                                "member_1".to_string(),
+                                PropertyValue::StringValue("test".to_string())
+                            ),
+                            ("member_2".to_string(), PropertyValue::IntValue(10))
+                        ])
+                    }])
+                ),])
+            }]),
+            PropertyValue::IntValue(7),
+        ],
+        prop_value
+    );
+
+    // The properties of the objects following the nested list must be unaffected by its parsing.
+    for index in 1..=2 {
+        assert_eq!(
+            objects
+                .get_object(index)
+                .unwrap()
+                .properties
+                .get("object property"),
+            Some(&PropertyValue::ObjectValue(0)),
+            "property of object {} was corrupted by list parsing",
+            index
+        );
+    }
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use tiled::{
-    Color, FiniteTileLayer, HorizontalAlignment, LayerType, Loader, Map, ObjectShape, Properties,
-    PropertyValue, ResourceCache, TileLayer, TilesetLocation, VerticalAlignment, WangId,
+    Color, FillMode, FiniteTileLayer, HorizontalAlignment, LayerType, Loader, Map, ObjectAlignment,
+    ObjectShape, Properties, PropertyValue, ResourceCache, TileLayer, TileRenderSize,
+    TilesetLocation, VerticalAlignment, WangId,
 };
 
 fn as_finite<'map>(data: TileLayer<'map>) -> FiniteTileLayer<'map> {
@@ -187,6 +188,24 @@ fn test_just_tileset() {
         r.tilesets()[0],
         loader.cache().get_tileset("assets/tilesheet.tsx").unwrap()
     );
+}
+
+#[test]
+fn test_tileset_render_options() {
+    let mut loader = Loader::new();
+
+    let t = loader
+        .load_tsx_tileset("assets/tilesheet_render_options.tsx")
+        .unwrap();
+    assert_eq!(t.tile_render_size, TileRenderSize::Grid);
+    assert_eq!(t.fill_mode, FillMode::PreserveAspectFit);
+    assert_eq!(t.object_alignment, ObjectAlignment::TopLeft);
+
+    // A tileset without these attributes gets the default values.
+    let t = loader.load_tsx_tileset("assets/tilesheet.tsx").unwrap();
+    assert_eq!(t.tile_render_size, TileRenderSize::Tile);
+    assert_eq!(t.fill_mode, FillMode::Stretch);
+    assert_eq!(t.object_alignment, ObjectAlignment::Unspecified);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -19,6 +19,8 @@ fn compare_everything_but_sources(r: &Map, e: &Map) {
     assert_eq!(r.height, e.height);
     assert_eq!(r.tile_width, e.tile_width);
     assert_eq!(r.tile_height, e.tile_height);
+    assert_eq!(r.skew_x, e.skew_x);
+    assert_eq!(r.skew_y, e.skew_y);
     assert_eq!(r.properties, e.properties);
     assert_eq!(r.background_color, e.background_color);
     assert_eq!(r.infinite(), e.infinite());
@@ -185,6 +187,17 @@ fn test_just_tileset() {
         r.tilesets()[0],
         loader.cache().get_tileset("assets/tilesheet.tsx").unwrap()
     );
+}
+
+#[test]
+fn test_oblique_map() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_oblique.tmx")
+        .unwrap();
+
+    assert_eq!(r.orientation, tiled::Orientation::Oblique);
+    assert_eq!(r.skew_x, 16);
+    assert_eq!(r.skew_y, 8);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -459,6 +459,32 @@ fn test_repeat() {
 }
 
 #[test]
+fn test_capsule_object_and_blend_modes() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_object_capsule.tmx")
+        .unwrap();
+
+    assert_eq!(r.get_layer(0).unwrap().blend_mode, "multiply");
+
+    let layer = r.get_layer(1).unwrap();
+    assert_eq!(layer.blend_mode, "add");
+
+    let objects = layer.as_object_layer().unwrap();
+    let capsule = objects.get_object(0).unwrap();
+    assert_eq!(
+        capsule.shape,
+        ObjectShape::Capsule {
+            width: 16.0,
+            height: 48.0
+        }
+    );
+    assert_eq!(capsule.opacity, 0.5);
+
+    // An object without an opacity attribute gets the default value.
+    assert_eq!(objects.get_object(1).unwrap().opacity, 1.0);
+}
+
+#[test]
 fn test_object_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_object_property.tmx")

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -115,7 +115,7 @@ fn test_world_pattern() {
 
     let paths = vec!["bad_map.tmx", "OVERFLOW-x099-y099.tmx"];
 
-    let errors = vec![
+    let errors = [
         "No match found for path: 'bad_map.tmx'",
         "Range error: Capture x * multiplierX causes overflow",
     ];
@@ -123,7 +123,7 @@ fn test_world_pattern() {
     let matches = e.match_paths(&paths);
 
     for (index, result) in matches.iter().enumerate() {
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
         assert_eq!(result.as_ref().err().unwrap().to_string(), errors[index]);
     }
 }
@@ -298,7 +298,7 @@ fn test_tile_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) = r.tilesets()[0]
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) = r.tilesets()[0]
         .get_tile(1)
         .unwrap()
         .properties
@@ -316,7 +316,7 @@ fn test_layer_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) =
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) =
         r.get_layer(0).unwrap().properties.get("prop3")
     {
         v.clone()
@@ -334,7 +334,7 @@ fn test_object_group_property() {
     let group_layer = r.get_layer(1).unwrap();
     let group_layer = group_layer.as_group_layer().unwrap();
     let sub_layer = group_layer.get_layer(0).unwrap();
-    let prop_value: bool = if let Some(&PropertyValue::BoolValue(ref v)) =
+    let prop_value: bool = if let Some(PropertyValue::BoolValue(v)) =
         sub_layer.properties.get("an object group property")
     {
         *v
@@ -349,7 +349,7 @@ fn test_tileset_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64.tmx")
         .unwrap();
-    let prop_value: String = if let Some(&PropertyValue::StringValue(ref v)) =
+    let prop_value: String = if let Some(PropertyValue::StringValue(v)) =
         r.tilesets()[0].properties.get("tileset property")
     {
         v.clone()
@@ -453,8 +453,8 @@ fn test_repeat() {
             3 => {
                 assert_eq!(layer.name, "ImageLayer");
                 let image_layer = layer.as_image_layer().unwrap();
-                assert_eq!(image_layer.repeat_x, true);
-                assert_eq!(image_layer.repeat_y, true);
+                assert!(image_layer.repeat_x);
+                assert!(image_layer.repeat_y);
             }
             _ => panic!("unexpected layer"),
         }
@@ -808,7 +808,7 @@ fn test_reading_wang_sets() {
         .unwrap();
 
     // We will pick some random data from the wangsets for tessting
-    let tileset = map.tilesets().get(0).unwrap();
+    let tileset = map.tilesets().first().unwrap();
     assert_eq!(
         tileset.transformations,
         tiled::Transformations {
@@ -819,7 +819,7 @@ fn test_reading_wang_sets() {
         }
     );
     assert_eq!(tileset.wang_sets.len(), 3);
-    let wangset_1 = tileset.wang_sets.get(0).unwrap();
+    let wangset_1 = tileset.wang_sets.first().unwrap();
     assert_eq!(wangset_1.user_type, "VoidSet");
     assert_eq!(wangset_1.wang_colors[0].user_type, "VoidColor");
     let wangset_2 = tileset.wang_sets.get(1).unwrap();
@@ -857,7 +857,7 @@ fn test_text_object() {
         } => {
             assert_eq!(font_family.as_str(), "sans-serif");
             assert_eq!(*pixel_size, 16);
-            assert_eq!(*wrap, false);
+            assert!(!(*wrap));
             assert_eq!(
                 *color,
                 Color {
@@ -867,11 +867,11 @@ fn test_text_object() {
                     alpha: 100
                 }
             );
-            assert_eq!(*bold, true);
-            assert_eq!(*italic, true);
-            assert_eq!(*underline, true);
-            assert_eq!(*strikeout, true);
-            assert_eq!(*kerning, true);
+            assert!(*bold);
+            assert!(*italic);
+            assert!(*underline);
+            assert!(*strikeout);
+            assert!(*kerning);
             assert_eq!(*halign, HorizontalAlignment::Center);
             assert_eq!(*valign, VerticalAlignment::Bottom);
             assert_eq!(text.as_str(), "Test");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -820,11 +820,8 @@ fn test_reading_wang_sets() {
     );
     assert_eq!(tileset.wang_sets.len(), 3);
     let wangset_1 = tileset.wang_sets.get(0).unwrap();
-    assert_eq!(wangset_1.user_type.as_deref(), Some("VoidSet"));
-    assert_eq!(
-        wangset_1.wang_colors[0].user_type.as_deref(),
-        Some("VoidColor")
-    );
+    assert_eq!(wangset_1.user_type, "VoidSet");
+    assert_eq!(wangset_1.wang_colors[0].user_type, "VoidColor");
     let wangset_2 = tileset.wang_sets.get(1).unwrap();
     let tile_10 = wangset_2.wang_tiles.get(&10).unwrap();
     assert_eq!(tile_10.wang_id, WangId([2u8, 2, 0, 2, 0, 2, 2, 2]));

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -406,6 +406,9 @@ fn test_parallax_layers() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_parallax.tmx")
         .unwrap();
+    assert_eq!(r.render_order, tiled::RenderOrder::RightUp);
+    assert_eq!(r.parallax_origin_x, 120.0);
+    assert_eq!(r.parallax_origin_y, -40.5);
     for (i, layer) in r.layers().enumerate() {
         match i {
             0 => {
@@ -470,6 +473,8 @@ fn test_capsule_object_and_blend_modes() {
     assert_eq!(layer.blend_mode, "add");
 
     let objects = layer.as_object_layer().unwrap();
+    assert_eq!(objects.draw_order, tiled::DrawOrder::Index);
+
     let capsule = objects.get_object(0).unwrap();
     assert_eq!(
         capsule.shape,
@@ -489,6 +494,15 @@ fn test_object_property() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_object_property.tmx")
         .unwrap();
+    // An object layer without a draworder attribute gets the default value.
+    assert_eq!(
+        r.get_layer(1)
+            .unwrap()
+            .as_object_layer()
+            .unwrap()
+            .draw_order,
+        tiled::DrawOrder::TopDown
+    );
     let layer = r.get_layer(1).unwrap();
     let prop_value = if let Some(PropertyValue::ObjectValue(v)) = layer
         .as_object_layer()
@@ -795,7 +809,22 @@ fn test_reading_wang_sets() {
 
     // We will pick some random data from the wangsets for tessting
     let tileset = map.tilesets().get(0).unwrap();
+    assert_eq!(
+        tileset.transformations,
+        tiled::Transformations {
+            hflip: true,
+            vflip: true,
+            rotate: false,
+            prefer_untransformed: true,
+        }
+    );
     assert_eq!(tileset.wang_sets.len(), 3);
+    let wangset_1 = tileset.wang_sets.get(0).unwrap();
+    assert_eq!(wangset_1.user_type.as_deref(), Some("VoidSet"));
+    assert_eq!(
+        wangset_1.wang_colors[0].user_type.as_deref(),
+        Some("VoidColor")
+    );
     let wangset_2 = tileset.wang_sets.get(1).unwrap();
     let tile_10 = wangset_2.wang_tiles.get(&10).unwrap();
     assert_eq!(tile_10.wang_id, WangId([2u8, 2, 0, 2, 0, 2, 2, 2]));


### PR DESCRIPTION
Brings all 0.16 development into `current`, in preparation of renaming `current` to `main` and retiring the `next` branch. The current/next split has been a recurring source of confusion for contributors, so future development will happen on a single `main` branch.

Includes the CI workflow update to trigger on `main`.