### PR TITLE
Prepare for v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.0]
 ### Added
 - Added the `Oblique` variant to the `Orientation` enum, which is a breaking
   change for code that matches on it exhaustively.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiled"
-version = "0.15.1"
+version = "0.16.0"
 description = "A rust crate for loading maps created by the Tiled editor"
 categories = ["game-development"]
 keywords = ["gamedev", "tiled", "tmx", "map"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rs-tiled
 ```toml
-tiled = "0.15.1"
+tiled = "0.16.0"
 ```
 
 [![Rust](https://github.com/mapeditor/rs-tiled/actions/workflows/rust.yml/badge.svg)](https://github.com/mapeditor/rs-tiled/actions/workflows/rust.yml)


### PR DESCRIPTION
Renames the Unreleased changelog section to 0.16.0 and bumps the version in Cargo.toml and the README.