### PR TITLE
Add test for flipped tile objects

### DIFF
--- a/assets/tiled_object_template.tmx
+++ b/assets/tiled_object_template.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.11" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="3" height="3" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="4">
+<map version="1.11" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="3" height="3" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="6">
  <tileset firstgid="1" source="tilesheet.tsx"/>
  <layer id="1" name="Tile Layer 1" width="3" height="3">
   <data encoding="csv">
@@ -15,5 +15,7 @@
   </object>
   <object id="2" gid="45" x="0" y="32" width="32" height="32"/>
   <object id="3" template="tiled_object_template.tx" x="0" y="64" width="64" height="32"/>
+  <object id="4" gid="3221225517" x="64" y="32" width="32" height="32"/>
+  <object id="5" gid="536870957" x="64" y="64" width="32" height="32"/>
  </objectgroup>
 </map>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -774,6 +774,35 @@ fn test_object_template_property() {
 }
 
 #[test]
+fn test_flipped_tile_objects() {
+    let r = Loader::new()
+        .load_tmx_map("assets/tiled_object_template.tmx")
+        .unwrap();
+    let object_layer = r.get_layer(1).unwrap().as_object_layer().unwrap();
+
+    // Unflipped tile object
+    let tile = object_layer.get_object(1).unwrap().get_tile().unwrap();
+    assert_eq!(tile.id(), 44);
+    assert!(!tile.flip_h);
+    assert!(!tile.flip_v);
+    assert!(!tile.flip_d);
+
+    // Tile object flipped both horizontally and vertically
+    let tile = object_layer.get_object(3).unwrap().get_tile().unwrap();
+    assert_eq!(tile.id(), 44);
+    assert!(tile.flip_h);
+    assert!(tile.flip_v);
+    assert!(!tile.flip_d);
+
+    // Tile object flipped diagonally
+    let tile = object_layer.get_object(4).unwrap().get_tile().unwrap();
+    assert_eq!(tile.id(), 44);
+    assert!(!tile.flip_h);
+    assert!(!tile.flip_v);
+    assert!(tile.flip_d);
+}
+
+#[test]
 fn test_templates() {
     let mut loader = Loader::new();
     let map = loader.load_tmx_map("assets/templates/example.tmx").unwrap();


### PR DESCRIPTION
Closes #144.

Most of what that issue asks for turned out to already be covered: `test_object_template_property` asserts the tile id, `TilesetLocation::Map`/`Template` distinction and tileset resolution for both direct and templated tile objects. The remaining gap was the flip flags, which no test asserted for tile objects (`test_flipped` only covers layer tiles).

Adds two flipped tile objects to `tiled_object_template.tmx` (one flipped horizontally+vertically, one diagonally) and a test asserting the flags and tile id for those plus the unflipped object.